### PR TITLE
FUEL-521 Too many connections

### DIFF
--- a/deployment/puppet/mysql/templates/my.cnf.erb
+++ b/deployment/puppet/mysql/templates/my.cnf.erb
@@ -24,6 +24,7 @@ query_cache_size   = 16M
 log_error          = <%= log_error %>
 expire_logs_days   = 10
 max_binlog_size    = 100M
+max_connections    = 512
 <% if default_engine != 'UNSET' %>
 default-storage-engine = <%= default_engine %>
 <% end %>


### PR DESCRIPTION
Increased default connection number for simple installation to 512.
