### PR TITLE
Removed puppetdb and puppetmaster from first stage of masternode provision. 

### DIFF
--- a/iso/ks.cfg
+++ b/iso/ks.cfg
@@ -5,7 +5,8 @@ reboot --eject
 lang en_US.UTF-8
 selinux --disabled
 #url --url http://172.18.67.168/centos-repo/centos-6.3
-url --url http://mirror.stanford.edu/yum/pub/centos/6.3/os/x86_64/
+#url --url http://mirror.stanford.edu/yum/pub/centos/6.3/os/x86_64/
+url --url http://mirror.centos.org/centos/6.3/os/x86_64/
 network --bootproto=dhcp
 repo --name=Base --mirrorlist=http://mirrorlist.centos.org/?release=6.3&arch=x86_64&repo=os
 repo --name=Updates --mirrorlist=http://mirrorlist.centos.org/?release=6.3&arch=x86_64&repo=updates
@@ -71,7 +72,6 @@ echo "bootloader --location=mbr --driveorder=${tgtdrive}" > /tmp/bootloader.ks
 echo "partition / --fstype=ext4 --ondisk=${tgtdrive} --size=1 --grow --asprimary" > /tmp/partition.ks
 echo "partition swap --recommended --ondisk=${tgtdrive}" >> /tmp/partition.ks
 
-
 %end
 
 %packages --nobase --excludedocs
@@ -81,8 +81,6 @@ curl
 crontabs
 cronie
 puppet-2.7.19
-puppet-server-2.7.19
-puppetdb
 python-argparse
 mcollective
 mcollective-client
@@ -114,8 +112,6 @@ centos_dir="${repodir}/centos/6.3/os/x86_64"
 mkdir -p ${centos_dir}
 cp -r ${SOURCE}/images ${centos_dir}
 cp -r ${SOURCE}/isolinux ${centos_dir}
-#cp -r ${SOURCE}/repodata ${centos_dir}
-#cp -r ${SOURCE}/Packages ${centos_dir}
 cp -r ${SOURCE}/ubuntu ${repodir}
 cp -r ${SOURCE}/astute*.gem ${repodir}
 


### PR DESCRIPTION
Mirror changed from stanford to official centos.
Puppetdb and puppetmaster now excluded from first stage.
