### PR TITLE
Proxy support, Make options for mirror redefine restored

### DIFF
--- a/deployment/puppet/cobbler/manifests/snippets.pp
+++ b/deployment/puppet/cobbler/manifests/snippets.pp
@@ -15,6 +15,8 @@ class cobbler::snippets {
   cobbler_snippet {"post_part_controller":}
   cobbler_snippet {"post_part_storage":}
 
+  cobbler_snippet {"url_proxy":}
+
   cobbler_snippet {"puppet_install_if_enabled":}
   cobbler_snippet {"puppet_conf":}
   cobbler_snippet {"puppet_register_if_enabled":}

--- a/deployment/puppet/cobbler/templates/kickstart/centos.ks.erb
+++ b/deployment/puppet/cobbler/templates/kickstart/centos.ks.erb
@@ -2,7 +2,7 @@
 install
 
 # INSTALLATION SOURCE (centos repository)
-url --url=$tree
+$SNIPPET('url_proxy')
 
 # ALTERNATIVE REPOSITORIES
 <% if ks_repo.kind_of?(Array)  %>

--- a/deployment/puppet/cobbler/templates/preseed/ubuntu-1204.preseed.erb
+++ b/deployment/puppet/cobbler/templates/preseed/ubuntu-1204.preseed.erb
@@ -80,7 +80,7 @@ d-i mirror/protocol string http
 d-i mirror/country string manual
 d-i mirror/http/hostname string $tree_host
 d-i mirror/http/directory string $tree_url
-d-i mirror/http/proxy string
+d-i mirror/http/proxy string $proxy
 
 d-i mirror/suite string precise
 # Suite to use for loading installer components (optional).

--- a/deployment/puppet/cobbler/templates/snippets/url_proxy.erb
+++ b/deployment/puppet/cobbler/templates/snippets/url_proxy.erb
@@ -1,0 +1,6 @@
+## add proxy to initial installation process if it defined in cobbler
+#if $getVar("proxy","") != ""
+url --proxy $proxy --url=$tree
+#else
+url --url=$tree
+#end if

--- a/iso/Makefile
+++ b/iso/Makefile
@@ -93,11 +93,11 @@ $(ISOROOT)/isolinux/isolinux.cfg: $(SOURCE_DIR)/isolinux/isolinux.cfg ; $(ACTION
 $(ISOROOT)/ks.cfg: $(SOURCE_DIR)/ks.cfg; $(ACTION.COPY)
 	[ -z "$$TGTDRIVE" ] || sed -i "s/^\(tgtdrive=\)\".*\"$$/\1\"$$TGTDRIVE\"/" $@
 	[ -z "$$USEEXTIF" ] || sed -i "s/^\(network\s*--bootproto=dhcp\.*\)/\1 --device=$$USEEXTIF/" $@
-	[ -z "$$ISO_URL" ] || sed -i "s/^url --url\.*/url --url $$ISO_URL/" $@
-	[ -z "$$BASE_MIRROR" ] || sed -i "s/^repo --name=Base\.*/repo --name=Base --mirrorlist=$$BASE_MIRROR/" $@
-	[ -z "$$UPDATES_MIRROR" ] || sed -i "s/^repo --name=Updates\.*/repo --name=Updates --mirrorlist=$$UPDATES_MIRROR/" $@
-	[ -z "$$MIRANTIS_MIRROR" ] || sed -i "s/^repo --name=Mirantis\.*/repo --name=Mirantis --mirrorlist=$$MIRANTIS_MIRROR/" $@
-	[ -z "$$PUPPETLABS_MIRROR" ] || sed -i "s/^repo --name=PuppetLabs\.*/repo --name=PuppetLabs --mirrorlist=$$PUPPETLABS_MIRROR/" $@
+	[ -z "$$ISO_URL" ] || sed -i "s/^#?url --url\.*/url --url $$ISO_URL/" $@
+	[ -z "$$BASE_MIRROR" ] || sed -i "s/^#?repo --name=Base\.*/repo --name=Base --mirrorlist=$$BASE_MIRROR/" $@
+	[ -z "$$UPDATES_MIRROR" ] || sed -i "s/^#?repo --name=Updates\.*/repo --name=Updates --mirrorlist=$$UPDATES_MIRROR/" $@
+	[ -z "$$MIRANTIS_MIRROR" ] || sed -i "s/^#?repo --name=Mirantis\.*/repo --name=Mirantis --mirrorlist=$$MIRANTIS_MIRROR/" $@
+	[ -z "$$PUPPETLABS_MIRROR" ] || sed -i "s/^#?repo --name=PuppetLabs\.*/repo --name=PuppetLabs --mirrorlist=$$PUPPETLABS_MIRROR/" $@
 $(ISOROOT)/bootstrap_admin_node.sh: $(SOURCE_DIR)/bootstrap_admin_node.sh ; $(ACTION.COPY)
 $(ISOROOT)/functions.sh: $(SOURCE_DIR)/functions.sh ; $(ACTION.COPY)
 $(ISOROOT)/bootstrap_admin_node.conf: $(SOURCE_DIR)/bootstrap_admin_node.conf ; $(ACTION.COPY)

--- a/iso/ks.cfg
+++ b/iso/ks.cfg
@@ -4,8 +4,8 @@ text
 reboot --eject
 lang en_US.UTF-8
 selinux --disabled
-#url --url http://172.18.67.168/centos-repo/centos-6.3
-#url --url http://mirror.stanford.edu/yum/pub/centos/6.3/os/x86_64/
+##url --url http://172.18.67.168/centos-repo/centos-6.3
+##url --url http://mirror.stanford.edu/yum/pub/centos/6.3/os/x86_64/
 url --url http://mirror.centos.org/centos/6.3/os/x86_64/
 network --bootproto=dhcp
 #repo --name=Base --mirrorlist=http://mirrorlist.centos.org/?release=6.3&arch=x86_64&repo=os


### PR DESCRIPTION
Proxy support during pxe-boot was added for both Ubuntu and CentOS.
Restored ability to reconfigure mirrors during make iso procedure
