### PR TITLE
fix cinder string or array check

### DIFF
--- a/deployment/puppet/openstack/manifests/compute.pp
+++ b/deployment/puppet/openstack/manifests/compute.pp
@@ -161,10 +161,10 @@ class openstack::compute (
 
   #Evaluate cinder node selection
   if ($cinder) {
-    if ($cinder_nodes == 'compute') or ($cinder_nodes == 'all') or (member($cinder_nodes,'all')) {
+    if ($cinder_nodes == 'compute') or ($cinder_nodes == 'all') {
       $cinder_compute = true
     } elsif (is_array($cinder_nodes)) {
-      if (member($cinder_nodes,'compute')) {
+      if (member($cinder_nodes,'compute')) or (member($cinder_nodes,'all')) {
         $cinder_compute = true
       } elsif (member($cinder_nodes,$::hostname)) {
         $cinder_compute = true

--- a/deployment/puppet/openstack/manifests/controller.pp
+++ b/deployment/puppet/openstack/manifests/controller.pp
@@ -188,10 +188,10 @@ class openstack::controller (
 
   #Evaluate cinder node selection
   if ($cinder) {
-    if ($cinder_nodes == 'controller') or ($cinder_nodes == 'all') or (member($cinder,'all')) {
+    if ($cinder_nodes == 'controller') or ($cinder_nodes == 'all') {
       $cinder_controller = true
     } elsif (is_array($cinder_nodes)) {
-      if (member($cinder_nodes,'controller')) {
+      if (member($cinder_nodes,'controller')) or (member($cinder,'all')) {
         $cinder_controller = true
       } elsif (member($cinder_nodes,$::hostname)) {
         $cinder_controller = true

--- a/deployment/puppet/openstack/manifests/swift/storage_node.pp
+++ b/deployment/puppet/openstack/manifests/swift/storage_node.pp
@@ -77,10 +77,10 @@ class openstack::swift::storage_node (
 
   #Evaluate cinder node selection
   if ($cinder) {
-    if ($cinder_nodes == 'storage') or ($cinder_nodes == 'all') or (member($cinder_nodes,'all')) {
+    if ($cinder_nodes == 'storage') or ($cinder_nodes == 'all') {
       $cinder_swift = true
-    } elsif (is_array($cinder_nodes)) {
-      if (member($cinder_nodes,'storage')) {
+    } elsif (is_array($cinder_nodes)){
+      if (member($cinder_nodes,'storage')) or (member($cinder_nodes,'all')) {
         $cinder_swift = true
       } elsif (member($cinder_nodes,$::hostname)) {
         $cinder_swift = true


### PR DESCRIPTION
Fixes this error: Error: Could not retrieve catalog from remote server: Error 400 on SERVER: member(): Requires array to work with at /etc/puppet/modules/openstack/manifests/controller.pp:191 on node fuel-controller-01.your-domain-name.com\x1b[0m\n', '\x1b[1;31mError: Could not retrieve catalog; skipping run
