### PR TITLE
fix cinder node selection for astute and docs

### DIFF
--- a/deployment/mcollective/astute/bin/openstack_system
+++ b/deployment/mcollective/astute/bin/openstack_system
@@ -186,8 +186,8 @@ class ConfigYaml
     self.mandatory('cinder')
   end
 
-  def cinder_on_computes()
-    self.mandatory('cinder_on_computes')
+  def cinder_nodes()
+    self.mandatory('cinder_nodes')
   end
 
   def use_syslog()
@@ -280,7 +280,7 @@ class Manifest
                      :nv_physical_volume => config.nv_physical_volumes(),
                      :use_syslog => config.use_syslog(),
                      :cinder => config.cinder(),
-                     :cinder_on_computes => config.cinder_on_computes(),
+                     :cinder_nodes => config.cinder_nodes(),
                      :nagios_master => config.nagios_master(),
                      :external_ipinfo => config.external_ip_info(),
                      :nodes => config.nodes(),

--- a/deployment/mcollective/astute/samples/config.yaml
+++ b/deployment/mcollective/astute/samples/config.yaml
@@ -36,7 +36,8 @@ common:
    default_gateway: 10.0.1.100
    nagios_master: fuel-controller-01.your-domain-name.com
    cinder: true
-   cinder_on_computes: true
+   cinder_nodes:
+   - controller
    swift: true
    repo_proxy: http://10.0.0.100:3128
    deployment_id: '53'

--- a/deployment/mcollective/astute/spec/manifest_spec.rb
+++ b/deployment/mcollective/astute/spec/manifest_spec.rb
@@ -36,7 +36,7 @@ describe "My behaviour" do
     config.controllers()
     config.loopback()
     config.cinder()
-    config.cinder_on_computes()
+    config.cinder_nodes()
     config.use_syslog()
     config.swift()
     config.default_gateway()

--- a/docs/pages/installation-instructions/0050-configuring-cobbler.rst
+++ b/docs/pages/installation-instructions/0050-configuring-cobbler.rst
@@ -66,7 +66,7 @@ Depending on how you've set up your network, you can either set the ``default_ga
    nagios_master: fuel-controller-01.your-domain-name.com
    loopback: loopback
    cinder: true
-   cinder_on_computes: true
+   cinder_nodes: [ 'controller' ]
    swift: true
 
 In this example, you're using Cinder and including it on the compute nodes, so note that appropriately.  Also, you're using Swift, so turn that on here. ::

--- a/docs/pages/installation-instructions/0060-deploying-openstack.rst
+++ b/docs/pages/installation-instructions/0060-deploying-openstack.rst
@@ -341,16 +341,16 @@ specified otherwise -- so let's look at what all of that means for the
 configuration. ::
 
 
-    ### CINDER/VOLUME ###
+   # Choose which nodes to install cinder onto
+   # 'compute'            -> compute nodes will run cinder
+   # 'controller'         -> controller nodes will run cinder
+   # 'storage'            -> storage nodes will run cinder
+   # 'fuel-controller-XX' -> specify particular host(s) by hostname
+   # 'XXX.XXX.XXX.XXX'    -> specify particular host(s) by IP address
+   # 'all'                -> compute, controller, and storage nodes will run cinder (excluding swift and proxy nodes)
+   $cinder_nodes          = ['controller']
     
-    # Should we use cinder or nova-volume(obsolete)
-    # Consult openstack docs for differences between them
-    $cinder = true
-    
-    # Should we install cinder on compute nodes?
-    $cinder_on_computes = true
-    
-We want Cinder to be on the compute nodes, so set this value to ``true``. ::
+We want Cinder to be on the controller nodes, so set this value to ``['controller']``. ::
 
 
 
@@ -825,7 +825,6 @@ Finally, back in ``site.pp``, you define the compute nodes::
 	    vncproxy_host          => $public_virtual_ip,
 	    verbose                => $verbose,
 	    vnc_enabled            => true,
-	    manage_volumes         => $manage_volumes,
 	    nova_user_password     => $nova_user_password,
 	    cache_server_ip        => $controller_hostnames,
 	    service_endpoint       => $internal_virtual_ip,
@@ -835,7 +834,8 @@ Finally, back in ``site.pp``, you define the compute nodes::
 	    quantum_host           => $quantum_net_node_address,
 	    tenant_network_type    => $tenant_network_type,
 	    segment_range          => $segment_range,
-	    cinder                 => $cinder_on_computes,
+	    cinder                 => $cinder,
+	    manage_volumes         => $is_cinder_node ? { true => $manage_volumes, false => false},
 	    cinder_iscsi_bind_iface=> $cinder_iscsi_bind_iface,
 	    nv_physical_volume     => $nv_physical_volume,
 	    db_host                => $internal_virtual_ip,

--- a/docs/pages/installation-instructions/config.yaml
+++ b/docs/pages/installation-instructions/config.yaml
@@ -28,7 +28,8 @@ common:
    nagios_master: fuel-controller-01.local
    loopback: loopback
    cinder: true
-   cinder_on_computes: true
+   cinder_nodes:
+   - controller
    swift: true
    dns_nameservers:
    - 10.0.0.100


### PR DESCRIPTION
Fixes:
openstack_system -c config.yaml    -t /etc/puppet/modules/openstack/examples/site_openstack_ha_compact.pp   -o /etc/puppet/manifests/site.pp   -a astute.yaml 
/usr/lib/ruby/gems/1.8/gems/astute-0.0.1/bin/openstack_system:116:in `mandatory': Undefined cinder_on_computes in template (RuntimeError)
    from /usr/lib/ruby/gems/1.8/gems/astute-0.0.1/bin/openstack_system:190:in`cinder_on_computes'
    from /usr/lib/ruby/gems/1.8/gems/astute-0.0.1/bin/openstack_system:283:in `prepare_manifest'
    from /usr/lib/ruby/gems/1.8/gems/astute-0.0.1/bin/openstack_system:371
    from /usr/lib/ruby/gems/1.8/gems/astute-0.0.1/bin/openstack_system:370:in`open'
    from /usr/lib/ruby/gems/1.8/gems/astute-0.0.1/bin/openstack_system:370
    from /usr/bin/openstack_system:19:in `load'
    from /usr/bin/openstack_system:19
