### PR TITLE
Fixes for upstream mysql and rsyslog

### DIFF
--- a/deployment/puppet/apt/manifests/pin.pp
+++ b/deployment/puppet/apt/manifests/pin.pp
@@ -9,14 +9,17 @@ define apt::pin(
   $origin     = '',
   $originator = '',
   $version    = '',
-  $order ='' 
+  $order ='',
+  $releasecustom = ''
 ) {
 
   include apt::params
 
   $preferences_d = $apt::params::preferences_d
-
-  if $release != '' {
+  if $releasecustom != '' {
+    $pin = "release $releasecustom"
+  }
+  elsif $release != '' {
     $pin = "release a=${release}"
   } elsif $origin != '' {
     $pin = "origin \"${origin}\""

--- a/deployment/puppet/openstack/manifests/mirantis_repos.pp
+++ b/deployment/puppet/openstack/manifests/mirantis_repos.pp
@@ -35,8 +35,8 @@ class openstack::mirantis_repos (
         apt::pin { 'upstream-mysql':
           order    => 19,
           priority => 1002,
-          version  => "5.5.29*",
-          packages => "mysql*"
+          releasecustom  => "v=12.04,o=Ubuntu",
+          packages => "/^mysql/"
         }
       }
 

--- a/deployment/puppet/rsyslog/templates/client.conf.erb
+++ b/deployment/puppet/rsyslog/templates/client.conf.erb
@@ -15,10 +15,13 @@ $ActionResumeRetryCount -1      # infinety retries if host is down
 <% if scope.lookupvar('rsyslog::client::log_remote') -%>
 # Log to remote syslog server using <%= scope.lookupvar('rsyslog::client::remote_type') %>
 <% scope.lookupvar('rsyslog::client::rservers_real').each do |rserver| -%>
+# Do not
+<% if ! ['localhost','127.0.0.1','::1'].include?(rserver['server']) and (scope.lookupvar('rsyslog::client::log_auth_local') or scope.lookupvar('rsyslog::client::log_local')) -%>
 <% if rserver['remote_type'] == 'tcp' -%>
 *.* @@<%= rserver['server']-%>:<%= rserver['port'] -%>;RSYSLOG_ForwardFormat
 <% else -%>
 *.* @<%= rserver['server'] -%>:<%= rserver['port'] -%>;RSYSLOG_ForwardFormat
+<% end -%>
 <% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
1. 
   a. Allow to specify custom release string in apt-pinning
   b. Install upstream mysql packages based on repo release info, not on packages version
   2.
   Break rsyslog loop when using syslog
