### PR TITLE
CI Grizzly disable ssh tests

### DIFF
--- a/deployment/puppet/quantum/manifests/agents/l3.pp
+++ b/deployment/puppet/quantum/manifests/agents/l3.pp
@@ -53,7 +53,7 @@ class quantum::agents::l3 (
   Quantum_config <| |> ~> Service['quantum-l3']
   Quantum_l3_agent_config <| |> ~> Service['quantum-l3']
   Quantum_l3_agent_config <| |> -> Quantum_router <| |>
-  Quantum_l3_agent_config <| |> -> Quantum_net['net04'] -> Quantum_net['net04_ext']
+  Quantum_l3_agent_config <| |> -> Quantum_net <| |>
   Quantum_l3_agent_config <| |> -> Quantum_subnet <| |>
 
   quantum_l3_agent_config {

--- a/deployment/puppet/quantum/manifests/agents/l3.pp
+++ b/deployment/puppet/quantum/manifests/agents/l3.pp
@@ -131,7 +131,6 @@ class quantum::agents::l3 (
         subnet_name  => 'subnet04',
         subnet_cidr  => $fixed_range,
         nameservers  => '8.8.4.4',
-        shared       => 'True',
       }
       Quantum_l3_agent_config <| |> -> Quantum::Network::Setup['net04']
 

--- a/fuel_test/prepare.py
+++ b/fuel_test/prepare.py
@@ -119,8 +119,8 @@ class Prepare(object):
             'FLAVOR_REF_ALT': '1', # skip flavor '2' which provides 20Gb ephemerals and lots of RAM...
             'COMPUTE_BUILD_INTERVAL': '10',
             'COMPUTE_BUILD_TIMEOUT': '600',
-            'RUN_SSH': 'true',
-            'NETWORK_FOR_SSH': 'net04', # todo use private instead of floating?
+            'RUN_SSH': 'false',
+            'NETWORK_FOR_SSH': 'net04_ext',
             'SSH_USER': 'cirros',
             'LIVE_MIGRATION': 'true',
             'USE_BLOCKMIG_FOR_LIVEMIG' : 'true',
@@ -162,7 +162,7 @@ class Prepare(object):
             'QUANTUM': 'true',
             'TENANT_NETS_REACHABLE': 'false',
             'TENANT_NETWORK_CIDR': '192.168.112.0/24', # choose do not overlap with 'net04'
-            'TENANT_NETWORK_MASK_BITS': '28', # 29 is too less to test quantum quotas (at least 50 ips needed)
+            'TENANT_NETWORK_MASK_BITS': '28', # 29 is not enougth to test quantum quotas
             'PUBLIC_NETWORK_ID': public_network_id,
             'PUBLIC_ROUTER_ID': public_router_id,
         }


### PR DESCRIPTION
Disable tempest ssh tests, unless L3 connectivity will be provided from jenkins slave to instances under test.
