### PR TITLE
start DHCP and L3 agents on different controllers if it's possible

### DIFF
--- a/deployment/puppet/corosync/lib/puppet/provider/service/pacemaker.rb
+++ b/deployment/puppet/corosync/lib/puppet/provider/service/pacemaker.rb
@@ -177,20 +177,25 @@ Puppet::Type.type(:service).provide :pacemaker, :parent => Puppet::Provider::Cor
       next unless node[:state] == :online
       debug("getting last ops on #{node[:uname]} for #{@resource[:name]}")
       all_operations =  XPath.match(@@cib,"cib/status/node_state[@uname='#{node[:uname]}']/lrm/lrm_resources/lrm_resource/lrm_rsc_op[starts-with(@id,'#{@resource[:name]}')]")
+      debug("ALL OPERATIONS:\n\n #{all_operations.inspect}")
       next if all_operations.nil?
       completed_ops = all_operations.select{|op| op.attributes['op-status'].to_i != -1 }
+      debug("COMPLETED OPERATIONS:\n\n #{completed_ops.inspect}")
       next if completed_ops.nil?
       start_stop_ops = completed_ops.select{|op| ["start","stop","monitor"].include? op.attributes['operation']}
+      debug("START/STOP OPERATIONS:\n\n #{start_stop_ops.inspect}")
       next if start_stop_ops.nil?
       sorted_operations = start_stop_ops.sort do
-        |a,b| a.attributes['call-id'] <=> b.attributes['call-id']
+        |a,b| a.attributes['call-id'].to_i <=> b.attributes['call-id'].to_i
       end
       good_operations = sorted_operations.select do |op|
         op.attributes['rc-code'] == '0' or
         op.attributes['operation'] == 'monitor'
       end
+      debug("GOOD OPERATIONS :\n\n #{good_operations.inspect}")
       next if good_operations.nil?
       last_op = good_operations.last
+      debug("LAST GOOD OPERATION :\n\n #{last_op.inspect}")
       next if last_op.nil?
       last_successful_op = nil
       if ['start','stop'].include?(last_op.attributes['operation'])
@@ -204,6 +209,7 @@ Puppet::Type.type(:service).provide :pacemaker, :parent => Puppet::Provider::Cor
           last_successful_op = 'start'
         end
       end
+      debug("LAST SUCCESSFUL OP :\n\n #{last_successful_op.inspect}")
       @last_successful_operations << last_successful_op if !last_successful_op.nil?
     end
     @last_successful_operations
@@ -214,7 +220,7 @@ Puppet::Type.type(:service).provide :pacemaker, :parent => Puppet::Provider::Cor
   #  end
 
   def enable
-    crm('resource','manage', @resource[:name])
+    crm('resource','manage', get_service_name)
   end
 
   def enabled?
@@ -223,7 +229,7 @@ Puppet::Type.type(:service).provide :pacemaker, :parent => Puppet::Provider::Cor
   end
 
   def disable
-    crm('resource','unmanage',@resource[:name])
+    crm('resource','unmanage',get_service_name)
   end
 
   #TODO: think about per-node start/stop/restart of services

--- a/deployment/puppet/corosync/manifests/init.pp
+++ b/deployment/puppet/corosync/manifests/init.pp
@@ -138,6 +138,16 @@ class corosync (
     require => Package['corosync']
   }
 
+  file { '/var/lib/pacemaker/cores/root':
+    ensure  => directory,
+    mode    => '0750',
+    owner   => 'hacluster',
+    group   => 'haclient',
+    recurse => true,
+    purge   => true,
+    require => Package['corosync']
+  }
+
   if $::osfamily == 'Debian' {
     exec { 'enable corosync':
       command => 'sed -i s/START=no/START=yes/ /etc/default/corosync',

--- a/deployment/puppet/quantum/manifests/agents/dhcp.pp
+++ b/deployment/puppet/quantum/manifests/agents/dhcp.pp
@@ -134,14 +134,14 @@ class quantum::agents::dhcp (
     cs_colocation { 'dhcp-with-ovs':
       ensure     => present,
       cib        => 'dhcp',
-      primitives => ["p_${::quantum::params::dhcp_agent_service}", "p_${::quantum::params::ovs_agent_service}"],
+      primitives => ["p_${::quantum::params::dhcp_agent_service}", "clone_p_${::quantum::params::ovs_agent_service}"],
       score      => 'INFINITY',
     }
 
     cs_order { 'dhcp-after-ovs':
       ensure => present,
       cib    => 'dhcp',
-      first  => "p_${::quantum::params::ovs_agent_service}",
+      first  => "clone_p_${::quantum::params::ovs_agent_service}",
       second => "p_${::quantum::params::dhcp_agent_service}",
       score  => 'INFINITY',
     }

--- a/deployment/puppet/quantum/manifests/agents/l3.pp
+++ b/deployment/puppet/quantum/manifests/agents/l3.pp
@@ -273,13 +273,13 @@ class quantum::agents::l3 (
     cs_colocation { 'l3-with-ovs':
       ensure     => present,
       cib        => 'l3',
-      primitives => ["p_${::quantum::params::l3_agent_service}", "p_${::quantum::params::ovs_agent_service}"],
+      primitives => ["p_${::quantum::params::l3_agent_service}", "clone_p_${::quantum::params::ovs_agent_service}"],
       score      => 'INFINITY',
     }
     cs_order { 'l3-after-ovs':
       ensure => present,
       cib    => 'l3',
-      first  => "p_${::quantum::params::ovs_agent_service}",
+      first  => "clone_p_${::quantum::params::ovs_agent_service}",
       second => "p_${::quantum::params::l3_agent_service}",
       score  => 'INFINITY',
     }

--- a/deployment/puppet/quantum/manifests/agents/l3.pp
+++ b/deployment/puppet/quantum/manifests/agents/l3.pp
@@ -276,13 +276,20 @@ class quantum::agents::l3 (
       primitives => ["p_${::quantum::params::l3_agent_service}", "p_${::quantum::params::ovs_agent_service}"],
       score      => 'INFINITY',
     }
-
     cs_order { 'l3-after-ovs':
       ensure => present,
       cib    => 'l3',
       first  => "p_${::quantum::params::ovs_agent_service}",
       second => "p_${::quantum::params::l3_agent_service}",
       score  => 'INFINITY',
+    }
+
+    # start DHCP and L3 agents on different controllers if it's possible
+    cs_colocation { 'dhcp-without-l3':
+      ensure     => present,
+      cib        => 'l3',
+      primitives => ["p_${::quantum::params::dhcp_agent_service}", "p_${::quantum::params::l3_agent_service}"],
+      score      => '-100',
     }
 
     # Ensure service is stopped  and disabled by upstart/init/etc.

--- a/deployment/puppet/quantum/manifests/agents/ovs.pp
+++ b/deployment/puppet/quantum/manifests/agents/ovs.pp
@@ -127,20 +127,20 @@ class quantum::agents::ovs (
       }
       default: { fail("The $::osfamily operating system is not supported.") }
     }
-    service { 'quantum-plugin-ovs-service_stopped':
+    service { 'quantum-ovs-agent-service_stopped':
       name       => $::quantum::params::ovs_agent_service,
       enable     => false,
       hasstatus  => false,
     }
-    exec { 'quantum-plugin-ovs-service_stopped':
+    exec { 'quantum-ovs-agent-service_stopped':
       name   => "bash -c \"service ${::quantum::params::ovs_agent_service} stop || ( kill `pgrep -f quantum-openvswitch-agent` || : )\"",
       onlyif => "service ${::quantum::params::ovs_agent_service} status | grep \'${started_status}\'",
       path   => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],
       returns => [0,""]
     }
     Package[$ovs_agent_package] ->
-      Service['quantum-plugin-ovs-service_stopped'] ->
-        Exec['quantum-plugin-ovs-service_stopped'] ->
+      Service['quantum-ovs-agent-service_stopped'] ->
+        Exec['quantum-ovs-agent-service_stopped'] ->
           Cs_resource["p_${::quantum::params::ovs_agent_service}"]
 
     service { 'quantum-plugin-ovs-service':

--- a/deployment/puppet/quantum/manifests/agents/ovs.pp
+++ b/deployment/puppet/quantum/manifests/agents/ovs.pp
@@ -133,6 +133,7 @@ class quantum::agents::ovs (
       hasstatus  => false,
     }
     exec { 'quantum-ovs-agent-service_stopped':
+      #todo: rewrite as script, that returns zero or wait, when it can return zero
       name   => "bash -c \"service ${::quantum::params::ovs_agent_service} stop || ( kill `pgrep -f quantum-openvswitch-agent` || : )\"",
       onlyif => "service ${::quantum::params::ovs_agent_service} status | grep \'${started_status}\'",
       path   => ['/usr/bin', '/usr/sbin', '/bin', '/sbin'],

--- a/deployment/puppet/quantum/manifests/agents/ovs.pp
+++ b/deployment/puppet/quantum/manifests/agents/ovs.pp
@@ -91,7 +91,13 @@ class quantum::agents::ovs (
       primitive_class => 'ocf',
       provided_by     => 'pacemaker',
       primitive_type  => 'quantum-agent-ovs',
-      require => File['quantum-ovs-agent'] ,
+      require         => File['quantum-ovs-agent'] ,
+      multistate_hash => {
+        'type' => 'clone',
+      },
+      ms_metadata     => {
+        'interleave' => 'true',
+      },
       parameters      => {
       }
       ,
@@ -108,7 +114,6 @@ class quantum::agents::ovs (
         'stop'     => {
           'timeout' => '480'
         }
-
       }
       ,
     }


### PR DESCRIPTION
This fix -- workarround for the inability to use network namespaces in RedHat in Centos
