### PR TITLE
Cirros version for fuel_tests

### DIFF
--- a/deployment/puppet/openstack/examples/site_openstack_single.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_single.pp
@@ -1,12 +1,6 @@
 #
-# Parameter values in this file should be changed, taking into consideration your
-# networking setup and desired OpenStack settings.
-# 
-# Please consult with the latest Fuel User Guide before making edits.
+# Example of how to deploy basic single openstack environment.
 #
-
-### GENERAL CONFIG ###
-# This section sets main parameters such as hostnames and IP addresses of different nodes
 
 # deploy a script that can be used to test nova
 class { 'openstack::test_file': }
@@ -24,35 +18,6 @@ $public_interface        = 'eth0'
 # this configuration assumes this interface is active but does not have an
 # ip address allocated to it.
 $private_interface       = 'eth1'
-
-$nodes_harr = [
-  {
-    'name' => 'fuel-controller-01',
-    'role' => 'primary-controller',
-    'internal_address' => '10.0.0.103',
-    'public_address'   => '10.0.204.103',
-  },
-]
-$nodes = $nodes_harr
-$default_gateway = '10.0.204.1'
-
-# Specify nameservers here.
-# Need points to cobbler node IP, or to special prepared nameservers if you known what you do.
-$dns_nameservers = ['10.0.204.1','8.8.8.8']
-
-# Specify netmasks for internal and external networks.
-$internal_netmask = '255.255.255.0'
-$public_netmask = '255.255.255.0'
-
-
-$node = filter_nodes($nodes,'name',$::hostname)
-$internal_address = $node[0]['internal_address']
-$public_address = $node[0]['public_address']
-
-#$controllers = merge_arrays(filter_nodes($nodes,'role','primary-controller'), filter_nodes($nodes,'role','controller'))
-#$controller_internal_address = $controllers[0]['internal_address']
-#$controller_public_address   = $controllers[0]['public_address']
-
 # credentials
 $admin_email             = 'root@localhost'
 $admin_password          = 'nova'
@@ -83,6 +48,7 @@ stage {'netconfig':
       before  => Stage['main'],
 }
 class {'l23network': stage=> 'netconfig'}
+$quantum_gre_bind_addr = $internal_address
 
 # Packages repo setup
 $mirror_type = 'default'
@@ -108,21 +74,17 @@ class {'openstack::clocksync': ntp_servers=>$ntp_servers}
 #connectinq to AMQP server are started.
 
 Exec<| title == 'clocksync' |>->Nova::Generic_service<| |>
+Exec<| title == 'clocksync' |>->Service<| title == 'quantum-l3' |>
+Exec<| title == 'clocksync' |>->Service<| title == 'quantum-dhcp-service' |>
+Exec<| title == 'clocksync' |>->Service<| title == 'quantum-ovs-plugin-service' |>
+Exec<| title == 'clocksync' |>->Service<| title == 'cinder-volume' |>
+Exec<| title == 'clocksync' |>->Service<| title == 'cinder-api' |>
+Exec<| title == 'clocksync' |>->Service<| title == 'cinder-scheduler' |>
 Exec<| title == 'clocksync' |>->Exec<| title == 'keystone-manage db_sync' |>
-Exec<| title == 'clocksync' |>->Exec<| title == 'keystone-manage pki_setup' |>
 Exec<| title == 'clocksync' |>->Exec<| title == 'glance-manage db_sync' |>
 Exec<| title == 'clocksync' |>->Exec<| title == 'nova-manage db sync' |>
 Exec<| title == 'clocksync' |>->Exec<| title == 'initial-db-sync' |>
 Exec<| title == 'clocksync' |>->Exec<| title == 'post-nova_config' |>
-
-
-
-
-### END OF PUBLIC CONFIGURATION PART ###
-# Normally, you do not need to change anything after this string 
-
-# Globally apply an environment-based tag to all resources on each node.
-tag("${::deployment_id}::${::environment}")
 
 stage { 'openstack-custom-repo': before => Stage['netconfig'] }
 class { 'openstack::mirantis_repos':
@@ -154,6 +116,7 @@ $openstack_version = {
   'horizon'          => 'latest',
   'nova'             => 'latest',
   'novncproxy'       => 'latest',
+  'cinder'           => 'latest',
   'rabbitmq_version' => $rabbitmq_version_string,
 }
 
@@ -165,7 +128,7 @@ node default {
   }
 
   class { 'openstack::all':
-    public_address          => $public_address,
+    public_address          => $ipaddress_eth0,
     public_interface        => $public_interface,
     private_interface       => $private_interface,
     admin_email             => $admin_email,

--- a/fuel_test/README.rst
+++ b/fuel_test/README.rst
@@ -55,7 +55,7 @@ Other shell script keys
 - CURRENT_PROFILE = ``centos64_x86_64`` or ``ubuntu_1204_x86_64`` - cobbler ks profile to use (default depends on OS_FAMILY)
 - CONTROLLERS,COMPUTES,STORAGES,PROXIES = number of nodes of corresponding role type to deploy (defaults ``3,3,3,2``)
 - PARENT_PROXY = parent-proxy server for squid at master node (``172.18.67.168`` Saratov, ``172.18.3.14`` Moscow) (default none)
-- CIRROS_IMAGE = cirros url (default ``http://srv08-srt.srt.mirantis.net/cirros-0.3.0-x86_64-disk.img``)
+- CIRROS_IMAGE = cirros url (default ``http://srv08-srt.srt.mirantis.net/cirros-$CIRROS_VERSION-x86_64-disk.img``)
 - CIRROS_VERSION = cirros version to use (default ``0.3.0``)
 - ISO_IMAGE = Fuel iso image to use for master node (default ``~/fuel-centos-6.4-x86_64.iso``)
 - USE_ISO  = use ISO for deployment (default ``True``), note: this option is broken

--- a/fuel_test/README.rst
+++ b/fuel_test/README.rst
@@ -56,6 +56,7 @@ Other shell script keys
 - CONTROLLERS,COMPUTES,STORAGES,PROXIES = number of nodes of corresponding role type to deploy (defaults ``3,3,3,2``)
 - PARENT_PROXY = parent-proxy server for squid at master node (``172.18.67.168`` Saratov, ``172.18.3.14`` Moscow) (default none)
 - CIRROS_IMAGE = cirros url (default ``http://srv08-srt.srt.mirantis.net/cirros-0.3.0-x86_64-disk.img``)
+- CIRROS_VERSION = cirros version to use (default ``0.3.0``)
 - ISO_IMAGE = Fuel iso image to use for master node (default ``~/fuel-centos-6.4-x86_64.iso``)
 - USE_ISO  = use ISO for deployment (default ``True``), note: this option is broken
 - ASTUTE_USE = use astute addon for mcollective to deploy nodes (default ``True``)

--- a/fuel_test/prepare.py
+++ b/fuel_test/prepare.py
@@ -9,7 +9,7 @@ import os
 from fuel_test.ci.ci_vm import CiVM
 from fuel_test.helpers import load, retry, install_packages, switch_off_ip_tables
 from fuel_test.root import root
-from fuel_test.settings import ADMIN_USERNAME, ADMIN_PASSWORD, ADMIN_TENANT_ESSEX, ADMIN_TENANT_FOLSOM, OS_FAMILY, CIRROS_IMAGE
+from fuel_test.settings import ADMIN_USERNAME, ADMIN_PASSWORD, ADMIN_TENANT_ESSEX, ADMIN_TENANT_FOLSOM, OS_FAMILY, CIRROS_IMAGE, CIRROS_VERSION
 
 
 class Prepare(object):
@@ -318,17 +318,17 @@ class Prepare(object):
         return image.id
 
     def tempest_add_images(self):
-        if not os.path.isfile('cirros-0.3.0-x86_64-disk.img'):
+        if not os.path.isfile('cirros-'+CIRROS_VERSION+'-x86_64-disk.img'):
             subprocess.check_call(['wget', CIRROS_IMAGE])
         glance = self._get_image_client()
-        images = self._get_images(glance, 'cirros_0.3.0')
+        images = self._get_images(glance, 'cirros_'+CIRROS_VERSION)
         if len(images) > 1:
             return images[0].id, images[1].id
         else:
-            return self.upload(glance, 'cirros_0.3.0',
-                           'cirros-0.3.0-x86_64-disk.img'), \
-               self.upload(glance, 'cirros_0.3.0',
-                           'cirros-0.3.0-x86_64-disk.img')
+            return self.upload(glance, 'cirros_'+CIRROS_VERSION,
+                           'cirros-'+CIRROS_VERSION+'-x86_64-disk.img'), \
+               self.upload(glance, 'cirros_'+CIRROS_VERSION,
+                           'cirros-'+CIRROS_VERSION+'-x86_64-disk.img')
 
     def tempest_get_netid_routerid(self):
         networking = self._get_networking_client()

--- a/fuel_test/settings.py
+++ b/fuel_test/settings.py
@@ -59,7 +59,7 @@ ADMIN_TENANT_ESSEX = 'openstack'
 ADMIN_TENANT_FOLSOM = 'admin'
 
 CIRROS_VERSION = os.environ.get('CIRROS_VERSION', '0.3.0')
-CIRROS_IMAGE = os.environ.get('CIRROS_IMAGE', 'http://srv08-srt.srt.mirantis.net/cirros-0.3.0-x86_64-disk.img')
+CIRROS_IMAGE = os.environ.get('CIRROS_IMAGE', 'http://srv08-srt.srt.mirantis.net/cirros-'+CIRROS_VERSION+'-x86_64-disk.img')
 CONTROLLERS = int(os.environ.get('CONTROLLERS', 3))
 COMPUTES = int(os.environ.get('COMPUTES', 3))
 STORAGES = int(os.environ.get('STORAGES', 3))

--- a/fuel_test/settings.py
+++ b/fuel_test/settings.py
@@ -58,6 +58,7 @@ ADMIN_PASSWORD = 'nova'
 ADMIN_TENANT_ESSEX = 'openstack'
 ADMIN_TENANT_FOLSOM = 'admin'
 
+CIRROS_VERSION = os.environ.get('CIRROS_VERSION', '0.3.0')
 CIRROS_IMAGE = os.environ.get('CIRROS_IMAGE', 'http://srv08-srt.srt.mirantis.net/cirros-0.3.0-x86_64-disk.img')
 CONTROLLERS = int(os.environ.get('CONTROLLERS', 3))
 COMPUTES = int(os.environ.get('COMPUTES', 3))


### PR DESCRIPTION
Add support for cirros 0.3.1 for tests
(Default cirros 0.3.0)

0.3.1 cirros boots faster and have a number of improvements
https://launchpad.net/cirros/+milestone/0.3.1/+index#
- move to buildroot 2012.05 (busybox 1.20.1)
- support https via curl/openssl (LP: #918702)
- ssh-import-id uses https directly to landscape.net
- support mounting of vfat filesystems (LP: #929841)
- (!) support acpi shutdown (LP: #944151)
- ec2metadata: remove double '/' in --public-keys requests (LP: #992492)
- upgrade kernel to Ubuntu 12.04 LTS kernel (3.2.0-37.58)
- mount first ephemeral device to /mnt in openstack instances (LP: #1022619)
- (!) ec2 data source has socket timeouts (10 second) when looking for metadata
  service (LP: #1022600)
- (!) wait longer than 3 seconds (60) for dhcp response on eth0 (LP: #918699)
- support openstack config-drive-v2 data source (LP: #1097488)
  including insertion of interfaces(5)
- support "NoCloud" data source, as supported by cloud-init (LP: #918375)
