### PR TITLE
Lock out puppet version everywhere

### DIFF
--- a/deployment/puppet/cobbler/templates/kickstart/centos.ks.erb
+++ b/deployment/puppet/cobbler/templates/kickstart/centos.ks.erb
@@ -116,6 +116,7 @@ $SNIPPET('mcollective_install_if_enabled')
 # HERE ARE COMMANDS THAT WILL BE LAUNCHED JUST AFTER
 # INSTALLATION ITSELF COMPLETED
 %post
+yum versionlock puppet
 echo -e "modprobe nf_conntrack_ipv4\nmodprobe nf_conntrack_ipv6" >> /etc/rc.modules
 chmod +x /etc/rc.modules
 echo -e "net.nf_conntrack_max=1048576" >> /etc/sysctl.conf

--- a/deployment/puppet/cobbler/templates/kickstart/centos.ks.erb
+++ b/deployment/puppet/cobbler/templates/kickstart/centos.ks.erb
@@ -102,6 +102,8 @@ wget
 crontabs
 cronie
 ruby-augeas
+yum-plugin-versionlock
+
 # COBBLER EMBEDDED SNIPPET: 'puppet_install_if_enabled'
 # LISTS puppet PACKAGE IF puppet_auto_setup VARIABLE IS SET TO 1
 $SNIPPET('puppet_install_if_enabled')

--- a/deployment/puppet/cobbler/templates/kickstart/rhel.ks.erb
+++ b/deployment/puppet/cobbler/templates/kickstart/rhel.ks.erb
@@ -100,6 +100,8 @@ wget
 crontabs
 cronie
 ruby-augeas
+yum-plugin-versionlock
+
 # COBBLER EMBEDDED SNIPPET: 'puppet_install_if_enabled'
 # LISTS puppet PACKAGE IF puppet_auto_setup VARIABLE IS SET TO 1
 $SNIPPET('puppet_install_if_enabled')

--- a/deployment/puppet/cobbler/templates/kickstart/rhel.ks.erb
+++ b/deployment/puppet/cobbler/templates/kickstart/rhel.ks.erb
@@ -114,6 +114,7 @@ $SNIPPET('mcollective_install_if_enabled')
 # HERE ARE COMMANDS THAT WILL BE LAUNCHED JUST AFTER
 # INSTALLATION ITSELF COMPLETED
 %post
+yum versionlock puppet
 echo -e "modprobe nf_conntrack_ipv4\nmodprobe nf_conntrack_ipv6" >> /etc/rc.modules
 chmod +x /etc/rc.modules
 echo -e "net.nf_conntrack_max=1048576" >> /etc/sysctl.conf

--- a/iso/bootstrap_admin_node.sh
+++ b/iso/bootstrap_admin_node.sh
@@ -40,6 +40,9 @@ puppet apply -e "
     class {puppetdb::master::config: puppet_service_name=>'thin'} "
 service thin restart
 
+yum versionlock puppet
+yum versionlock puppet-server
+
 # Walking aroung nginx's default server config
 rm -f /etc/nginx/conf.d/default.conf
 service nginx restart

--- a/iso/ks.cfg
+++ b/iso/ks.cfg
@@ -80,6 +80,7 @@ python-argparse
 mcollective
 mcollective-client
 rubygem-astute
+yum-plugin-versionlock
 man
 yum
 openssh-clients


### PR DESCRIPTION
Preventing 'yum update' potential harm. The other side is inability to do pull-updates in case of future bugs/security flaws on the puppet.
