### PR TITLE
Added explicit new Galera cluster start procedure

### DIFF
--- a/deployment/puppet/galera/manifests/init.pp
+++ b/deployment/puppet/galera/manifests/init.pp
@@ -14,8 +14,8 @@ class galera (
   $node_address         = $ipaddress_eth0,
   $setup_multiple_gcomm = true,
   $skip_name_resolve    = false,
-  $node_addresses       = [
-    $ipaddress_eth0]) {
+  $node_addresses       = [$ipaddress_eth0],
+  ) {
   include galera::params
 
   $mysql_user = $::galera::params::mysql_user
@@ -25,12 +25,12 @@ class galera (
   case $::osfamily {
     'RedHat' : {
 
-      if (!$::selinux == 'false') and !defined(Class['selinux']) {
-        class { 'selinux':
-          mode   => 'disabled',
-          before => Package['MySQL-server']
-        }
-      }
+#       if (!$::selinux == 'false') and !defined(Class['selinux']) {
+#         class { 'selinux':
+#           mode   => 'disabled',
+#           before => Package['MySQL-server']
+#         }
+#       }
 
       file { '/etc/init.d/mysql':
         ensure  => present,
@@ -65,12 +65,6 @@ class galera (
       }
     }
     'Debian' : {
-      if (!$::selinux == 'false') and !defined(Class['selinux']) {
-        class { 'selinux':
-          mode   => 'disabled',
-          before => Package['MySQL-server']
-        }
-      }
 
       file { '/etc/init.d/mysql':
         ensure  => present,
@@ -187,7 +181,7 @@ class galera (
 
   exec { "wait-initial-sync":
     logoutput   => true,
-    command     => "/usr/bin/mysql -Nbe \"show status like 'wsrep_local_state_comment'\" | /bin/grep -q Synced && sleep 10",
+    command     => "/usr/bin/mysql -Nbe \"show status like 'wsrep_local_state_comment'\" | /bin/grep -q -e Synced -e Initialized && sleep 10",
     try_sleep   => 5,
     tries       => 60,
     refreshonly => true,
@@ -224,5 +218,16 @@ class galera (
     primary_controller => $primary_controller,
     node_addresses => $node_addresses,
     node_address   => $node_address,
+  }
+  
+  if $primary_controller {
+    exec { "start-new-galera-cluster":
+      path   => "/usr/bin:/usr/sbin:/bin:/sbin",
+      logoutput => true,
+      command   => '/etc/init.d/mysql stop; sleep 10; killall -w mysqld && ( killall -w -9 mysqld_safe || : ) && sleep 10; /etc/init.d/mysql start --wsrep-cluster-address=gcomm:// &',
+      onlyif    => "[ -f /var/lib/mysql/grastate.dat ] && (cat /var/lib/mysql/grastate.dat | awk '\$1 == \"uuid:\" {print \$2}' | awk '{if (\$0 == \"00000000-0000-0000-0000-000000000000\") exit 0; else exit 1}')",
+      require    => Service["mysql-galera"],
+      before     => Exec ["wait-for-synced-state"],
+    }
   }
 }

--- a/deployment/puppet/galera/templates/wsrep.cnf.erb
+++ b/deployment/puppet/galera/templates/wsrep.cnf.erb
@@ -50,14 +50,10 @@ wsrep_provider_options="pc.ignore_sb = no;ist.recv_addr=<%= node_address %>;gmca
 # Logical cluster name. Should be the same for all nodes.
 wsrep_cluster_name="<%= cluster_name -%>"
 
-<% if primary_controller -%>
-wsrep_cluster_address="gcomm://"
+<% if setup_multiple_gcomm -%>
+wsrep_cluster_address="gcomm://<%= @node_addresses.reject{|ip| ip == hostname || ip == node_address || ip == l3_fqdn_hostname }.collect {|ip| ip + ':' + 4567.to_s }.join ',' %>?pc.wait_prim=no"
 <% else -%>
-    <% if setup_multiple_gcomm -%>
-wsrep_cluster_address="gcomm://<%= @node_addresses.reject{|ip| ip == hostname || ip == node_address || ip == l3_fqdn_hostname }.collect {|ip| ip + ':' + 4567.to_s }.join ',' %>"
-    <% else -%>
-wsrep_cluster_address="gcomm://<%= @node_addresses.first %>:4567"
-    <% end -%>
+wsrep_cluster_address="gcomm://<%= @node_addresses.first %>:4567?pc.wait_prim=no"
 <% end -%>
 
 # Human-readable node name (non-unique). Hostname by default.


### PR DESCRIPTION
Changed default template for mysql galera. 
Removed empty gcomm. 
Added explicit new Galera cluster start procedure, based on UUID value in /var/lib/mysql/grastate.dat. 
Removed SElinux disable code - it should not exist in galera manifest only but it should work on every node.
