### PR TITLE
FUEL-685, FUEL-691: Adding a missed apt.puppetlabs.com APT key in Ubuntu...

### DIFF
--- a/deployment/puppet/cobbler/examples/site.pp
+++ b/deployment/puppet/cobbler/examples/site.pp
@@ -109,6 +109,7 @@ node fuel-cobbler {
           {
             'name'    => 'Puppet',
             'url'     => 'http://apt.puppetlabs.com/',
+            'key'     => 'http://apt.puppetlabs.com/pubkey.gpg',
             'release' => 'precise',
             'repos'   => 'main dependencies',
           },

--- a/deployment/puppet/cobbler/manifests/profile/ubuntu_1204_x86_64.pp
+++ b/deployment/puppet/cobbler/manifests/profile/ubuntu_1204_x86_64.pp
@@ -1,5 +1,5 @@
 #
-# This class is intended to make cobbler profile rhel63_x86_64.
+# This class is intended to make cobbler profile ubuntu_1204_x86_64.
 #
 # [distro] The name of cobbler distro to bind profile to.
 #
@@ -13,6 +13,7 @@ class cobbler::profile::ubuntu_1204_x86_64(
     {
       "name" => "Puppet",
       "url"  => "http://apt.puppetlabs.com/",
+      "key"  => "http://apt.puppetlabs.com/pubkey.gpg",
       "release" => "precise",
       "repos" => "main dependencies",
     },


### PR DESCRIPTION
The fix have been tested succesfully on deployment.

To get this fix working in the production, you should rebuild the ISO file with fuel-pm and publish it again.
