### PR TITLE
no writables in /usr

### DIFF
--- a/deployment/puppet/horizon/manifests/init.pp
+++ b/deployment/puppet/horizon/manifests/init.pp
@@ -56,12 +56,6 @@ class horizon(
     require => Package[$::horizon::params::http_service],
   }
 
-  File {
-    require => Package['dashboard'],
-    owner   => $wsgi_user,
-    group   => $wsgi_group,
-  }
-
   file { $::horizon::params::local_settings_path:
     content => template('horizon/local_settings.py.erb'),
     mode    => '0644',


### PR DESCRIPTION
That completely fixes ill behaviour of the Horizon package. Should be tested on Centos.
