### PR TITLE
Add pipreqs for pyyaml psycopg2 ipaddr

### DIFF
--- a/fuel_test/pip-requires
+++ b/fuel_test/pip-requires
@@ -2,4 +2,7 @@ nose
 python-glanceclient
 python-keystoneclient
 python-quantumclient>=2.1
+pyyaml
+psycopg2
+ipaddr
 git+ssh://git@github.com/Mirantis/devops.git@stable


### PR DESCRIPTION
Those are needed for test environment setup.

Signed-off-by: Bogdan Dobrelya bogdando@mail.ru
