### PR TITLE
Undo fix for FUEL-546

### DIFF
--- a/deployment/puppet/quantum/manifests/agents/l3.pp
+++ b/deployment/puppet/quantum/manifests/agents/l3.pp
@@ -145,7 +145,7 @@ class quantum::agents::l3 (
         subnet_gw       => $external_gateway, # undef,
         alloc_pool      => $external_alloc_pool, # undef,
         enable_dhcp     => 'False', # 'True',
-        shared          => 'True',
+        shared          => 'False',
       }
       Quantum_l3_agent_config <| |> -> Quantum::Network::Setup['net04_ext']
 


### PR DESCRIPTION
net04_ext should be created as non shared, as it was before FUEL-546.

Signed-off-by: Bogdan Dobrelya bogdando@mail.ru
