### PR TITLE
Reset mysql module to 3.0.1 tag

### DIFF
--- a/deployment/puppet/mysql/lib/puppet/provider/database/mysql.rb
+++ b/deployment/puppet/mysql/lib/puppet/provider/database/mysql.rb
@@ -1,43 +1,37 @@
-$LOAD_PATH.push(File.join(File.dirname(__FILE__), '..', '..', '..'))
-require 'puppet/provider/mysql'
-
-Puppet::Type.type(:database).provide(
-  :mysql,
-  :parent => Puppet::Provider::Mysql,
-) do
+Puppet::Type.type(:database).provide(:mysql) do
 
   desc "Manages MySQL database."
 
   defaultfor :kernel => 'Linux'
 
-  commands :mysql      => 'mysql'
-  commands :mysqladmin => 'mysqladmin'
+  optional_commands :mysql      => 'mysql'
+  optional_commands :mysqladmin => 'mysqladmin'
 
   def self.instances
-    mysql(connection_options, '-NBe', 'show databases').split("\n").collect do |name|
+    mysql('-NBe', "show databases").split("\n").collect do |name|
       new(:name => name)
     end
   end
 
   def create
-    mysql(connection_options, '-NBe', "create database `#{@resource[:name]}` character set #{resource[:charset]}")
+    mysql('-NBe', "create database `#{@resource[:name]}` character set #{resource[:charset]}")
   end
 
   def destroy
-    mysqladmin(connection_options, '-f', 'drop', @resource[:name])
+    mysqladmin('-f', 'drop', @resource[:name])
   end
 
   def charset
-    mysql(connection_options, '-NBe', "show create database `#{@resource[:name]}`").match(/.*?(\S+)\s\*\//)[1]
+    mysql('-NBe', "show create database `#{resource[:name]}`").match(/.*?(\S+)\s\*\//)[1]
   end
 
   def charset=(value)
-    mysql(connection_options, '-NBe', "alter database `#{@resource[:name]}` CHARACTER SET #{value}")
+    mysql('-NBe', "alter database `#{resource[:name]}` CHARACTER SET #{value}")
   end
 
   def exists?
     begin
-      mysql(connection_options, '-NBe', 'show databases').match(/^#{@resource[:name]}$/)
+      mysql('-NBe', "show databases").match(/^#{@resource[:name]}$/)
     rescue => e
       debug(e.message)
       return nil

--- a/deployment/puppet/mysql/lib/puppet/provider/database_grant/mysql.rb
+++ b/deployment/puppet/mysql/lib/puppet/provider/database_grant/mysql.rb
@@ -2,19 +2,15 @@
 # of the name:
 #   user@host => global
 #   user@host/db => per-db
-$LOAD_PATH.push(File.join(File.dirname(__FILE__), '..', '..', '..'))
-require 'puppet/provider/mysql'
-Puppet::Type.type(:database_grant).provide(
-    :mysql,
-    :parent => Puppet::Provider::Mysql,
-) do
+
+Puppet::Type.type(:database_grant).provide(:mysql) do
 
   desc "Uses mysql as database."
 
   defaultfor :kernel => 'Linux'
 
-  commands :mysql      => 'mysql'
-  commands :mysqladmin => 'mysqladmin'
+  optional_commands :mysql      => 'mysql'
+  optional_commands :mysqladmin => 'mysqladmin'
 
   def self.prefetch(resources)
     @user_privs = nil
@@ -38,13 +34,13 @@ Puppet::Type.type(:database_grant).provide(
   end
 
   def self.query_user_privs
-    results = mysql('mysql', connection_options, '-Be', 'describe user')
+    results = mysql("mysql", "-Be", "describe user")
     column_names = results.split(/\n/).map { |l| l.chomp.split(/\t/)[0] }
     @user_privs = column_names.delete_if { |e| !( e =~/_priv$/) }
   end
 
   def self.query_db_privs
-    results = mysql('mysql', connection_options, '-Be', 'describe db')
+    results = mysql("mysql", "-Be", "describe db")
     column_names = results.split(/\n/).map { |l| l.chomp.split(/\t/)[0] }
     @db_privs = column_names.delete_if { |e| !(e =~/_priv$/) }
   end
@@ -78,11 +74,11 @@ Puppet::Type.type(:database_grant).provide(
       name = split_name(@resource[:name])
       case name[:type]
       when :user
-        mysql 'mysql', connection_options, '-e', "INSERT INTO user (host, user) VALUES ('%s', '%s')" % [
+        mysql "mysql", "-e", "INSERT INTO user (host, user) VALUES ('%s', '%s')" % [
           name[:host], name[:user],
         ]
       when :db
-        mysql 'mysql', connection_options, '-e', "INSERT INTO db (host, user, db) VALUES ('%s', '%s', '%s')" % [
+        mysql "mysql", "-e", "INSERT INTO db (host, user, db) VALUES ('%s', '%s', '%s')" % [
           name[:host], name[:user], name[:db],
         ]
       end
@@ -91,7 +87,7 @@ Puppet::Type.type(:database_grant).provide(
   end
 
   def destroy
-    mysql('mysql', connection_options, '-e', "REVOKE ALL ON '%s'.* FROM '%s@%s'" % [ @resource[:privileges], @resource[:database], @resource[:name], @resource[:host] ])
+    mysql "mysql", "-e", "REVOKE ALL ON '%s'.* FROM '%s@%s'" % [ @resource[:privileges], @resource[:database], @resource[:name], @resource[:host] ]
   end
 
   def row_exists?
@@ -100,7 +96,7 @@ Puppet::Type.type(:database_grant).provide(
     if name[:type] == :db
       fields << :db
     end
-    not mysql( 'mysql', connection_options, '-NBe', 'SELECT "1" FROM %s WHERE %s' % [ name[:type], fields.map do |f| "%s = '%s'" % [f, name[f]] end.join(' AND ')]).empty?
+    not mysql( "mysql", "-NBe", 'SELECT "1" FROM %s WHERE %s' % [ name[:type], fields.map do |f| "%s = '%s'" % [f, name[f]] end.join(' AND ')]).empty?
   end
 
   def all_privs_set?
@@ -122,9 +118,9 @@ Puppet::Type.type(:database_grant).provide(
 
     case name[:type]
     when :user
-      privs = mysql('mysql', connection_options, '-Be,' 'select * from user where user="%s" and host="%s"' % [ name[:user], name[:host] ])
+      privs = mysql "mysql", "-Be", 'select * from user where user="%s" and host="%s"' % [ name[:user], name[:host] ]
     when :db
-      privs = mysql('mysql', connection_options, '-Be', 'select * from db where user="%s" and host="%s" and db="%s"' % [ name[:user], name[:host], name[:db] ])
+      privs = mysql "mysql", "-Be", 'select * from db where user="%s" and host="%s" and db="%s"' % [ name[:user], name[:host], name[:db] ]
     end
 
     if privs.match(/^$/)
@@ -175,7 +171,7 @@ Puppet::Type.type(:database_grant).provide(
     # puts "set:", set
     stmt = stmt << set << where
 
-    mysql('mysql', connection_options, "-Be", stmt)
+    mysql "mysql", "-Be", stmt
     mysql_flush
   end
 end

--- a/deployment/puppet/mysql/lib/puppet/provider/database_user/mysql.rb
+++ b/deployment/puppet/mysql/lib/puppet/provider/database_user/mysql.rb
@@ -1,46 +1,42 @@
-$LOAD_PATH.push(File.join(File.dirname(__FILE__), '..', '..', '..'))
-require 'puppet/provider/mysql'
-Puppet::Type.type(:database_user).provide(
-    :mysql,
-    :parent => Puppet::Provider::Mysql,
-) do
+Puppet::Type.type(:database_user).provide(:mysql) do
 
   desc "manage users for a mysql database."
 
   defaultfor :kernel => 'Linux'
 
-  commands :mysql      => 'mysql'
-  commands :mysqladmin => 'mysqladmin'
+  optional_commands :mysql      => 'mysql'
+  optional_commands :mysqladmin => 'mysqladmin'
 
   def self.instances
-    users = mysql("mysql", mysql_cmd_string, '-BNe' "select concat(User, '@',Host) as User from mysql.user").split("\n")
+    users = mysql("mysql", '-BNe' "select concat(User, '@',Host) as User from mysql.user").split("\n")
     users.select{ |user| user =~ /.+@/ }.collect do |name|
       new(:name => name)
     end
   end
 
   def create
-      mysql('mysql', connection_options, '-e', "create user '%s' identified by PASSWORD '%s'" % [ @resource[:name].sub("@", "'@'"), @resource.value(:password_hash) ])
+    mysql("mysql", "-e", "create user '%s' identified by PASSWORD '%s'" % [ @resource[:name].sub("@", "'@'"), @resource.value(:password_hash) ])
   end
 
   def destroy
-      mysql('mysql', connection_options, '-e', "drop user '%s'" % @resource.value(:name).sub("@", "'@'") )
+    mysql("mysql", "-e", "drop user '%s'" % @resource.value(:name).sub("@", "'@'") )
   end
 
   def password_hash
-      mysql('mysql', connection_options, '-NBe', "select password from user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)).chomp
+    mysql("mysql", "-NBe", "select password from user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)).chomp
   end
 
   def password_hash=(string)
-      mysql("mysql", connection_options, '-e', "SET PASSWORD FOR '%s' = '%s'" % [ @resource[:name].sub("@", "'@'"), string ] )
+    mysql("mysql", "-e", "SET PASSWORD FOR '%s' = '%s'" % [ @resource[:name].sub("@", "'@'"), string ] )
   end
 
   def exists?
-      not mysql('mysql', connection_options, '-NBe', "select '1' from user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)).empty?
+    not mysql("mysql", "-NBe", "select '1' from user where CONCAT(user, '@', host) = '%s'" % @resource.value(:name)).empty?
   end
 
   def flush
     @property_hash.clear
     mysqladmin "flush-privileges"
   end
+
 end

--- a/deployment/puppet/mysql/lib/puppet/type/database.rb
+++ b/deployment/puppet/mysql/lib/puppet/type/database.rb
@@ -14,41 +14,4 @@ Puppet::Type.newtype(:database) do
     newvalue(/^\S+$/)
   end
 
-  # Connect to remote host
-  newproperty(:authorized_user) do
-    desc 'Authorization user to remote host'
-
-    defaultto 'root'
-  end
-
-  newproperty(:authorized_pass) do
-    desc 'Authorization password to remote host'
-
-    defaultto ''
-
-    munge do |value|
-      String(value)
-    end
-  end
-
-  newproperty(:host) do
-    desc 'Host for remote authorization'
-    validate do |value|
-      raise(ArgumentError, "Value: #{value} does not seems like IP") unless value =~ /^(\d{1,3}\.){3}\d{1,3}$/
-    end
-  end
-
-  newproperty(:port) do
-    desc 'Port for remote authorization'
-
-    defaultto '3306'
-
-    validate do |value|
-      raise(ArgumentError, " #{value} is incorrect port range ") unless (1025..48999).include? value.to_i
-    end
-
-    munge do |value|
-      String(value)
-    end
-  end
 end

--- a/deployment/puppet/mysql/lib/puppet/type/database_grant.rb
+++ b/deployment/puppet/mysql/lib/puppet/type/database_grant.rb
@@ -71,42 +71,5 @@ Puppet::Type.newtype(:database_grant) do
     end
   end
 
-  # Connect to remote host
-  newproperty(:authorized_user) do
-    desc 'Authorization user to remote host'
-
-    defaultto 'root'
-  end
-
-  newproperty(:authorized_pass) do
-    desc 'Authorization password to remote host'
-
-    defaultto ''
-
-    munge do |value|
-      String(value)
-    end
-  end
-
-  newproperty(:host) do
-    desc 'Host for remote authorization'
-    validate do |value|
-      raise(ArgumentError, "Value: #{value} does not seems like IP") unless value =~ /^(\d{1,3}\.){3}\d{1,3}$/
-    end
-  end
-
-  newproperty(:port) do
-    desc 'Port for remote authorization'
-
-    defaultto '3306'
-
-    validate do |value|
-      raise(ArgumentError, " #{value} is incorrect port range ") unless (1025..48999).include? value.to_i
-    end
-
-    munge do |value|
-      String(value)
-    end
-  end
 end
 

--- a/deployment/puppet/mysql/lib/puppet/type/database_user.rb
+++ b/deployment/puppet/mysql/lib/puppet/type/database_user.rb
@@ -22,41 +22,4 @@ Puppet::Type.newtype(:database_user) do
     newvalue(/\w+/)
   end
 
-  # Connect to remote host
-  newproperty(:authorized_user) do
-    desc 'Authorization user to remote host'
-
-    defaultto 'root'
-  end
-
-  newproperty(:authorized_pass) do
-    desc 'Authorization password to remote host'
-
-    defaultto ''
-
-    munge do |value|
-      String(value)
-    end
-  end
-
-  newproperty(:host) do
-    desc 'Host for remote authorization'
-    validate do |value|
-      raise(ArgumentError, "Value: #{value} does not seems like IP") unless value =~ /^(\d{1,3}\.){3}\d{1,3}$/
-    end
-  end
-
-  newproperty(:port) do
-    desc 'Port for remote authorization'
-
-    defaultto '3306'
-
-    validate do |value|
-      raise(ArgumentError, " #{value} is incorrect port range ") unless (1025..48999).include? value.to_i
-    end
-
-    munge do |value|
-      String(value)
-    end
-  end
 end

--- a/deployment/puppet/mysql/manifests/backup.pp
+++ b/deployment/puppet/mysql/manifests/backup.pp
@@ -25,18 +25,10 @@ class mysql::backup (
   $backupuser,
   $backuppassword,
   $backupdir,
-  $ensure = 'present',
-  $host = false,
-  $port = false,
-  $authorized_user = false,
-  $authorized_pass = false,
+  $ensure = 'present'
 ) {
 
   database_user { "${backupuser}@localhost":
-    host            => $host,
-    port            => $port,
-    authorized_user => $authorized_user,
-    authorized_pass => $authorized_pass,
     ensure        => $ensure,
     password_hash => mysql_password($backuppassword),
     provider      => 'mysql',
@@ -44,10 +36,6 @@ class mysql::backup (
   }
 
   database_grant { "${backupuser}@localhost":
-    host            => $host,
-    port            => $port,
-    authorized_user => $authorized_user,
-    authorized_pass => $authorized_pass,
     privileges => [ 'Select_priv', 'Reload_priv', 'Lock_tables_priv' ],
     require    => Database_user["${backupuser}@localhost"],
   }

--- a/deployment/puppet/mysql/manifests/db.pp
+++ b/deployment/puppet/mysql/manifests/db.pp
@@ -39,44 +39,27 @@ define mysql::db (
   $host        = 'localhost',
   $grant       = 'all',
   $sql         = '',
-  $enforce_sql = false,
-  $host = false,
-  $port = false,
-  $authorized_user = false,
-  $authorized_pass = false,
-
+  $enforce_sql = false
 ) {
 
   database { $name:
-    host            => $host,
-    port            => $port,
-    authorized_user => $authorized_user,
-    authorized_pass => $authorized_pass,
-    ensure          => present,
-    charset         => $charset,
-    provider        => 'mysql',
-    require         => Class['mysql::server'],
+    ensure   => present,
+    charset  => $charset,
+    provider => 'mysql',
+    require  => Class['mysql::server'],
   }
 
   database_user { "${user}@${host}":
-    ensure          => present,
-    host            => $host,
-    port            => $port,
-    authorized_user => $authorized_user,
-    authorized_pass => $authorized_pass,
-    password_hash   => mysql_password($password),
-    provider        => 'mysql',
-    require         => Database[$name],
+    ensure        => present,
+    password_hash => mysql_password($password),
+    provider      => 'mysql',
+    require       => Database[$name],
   }
 
   database_grant { "${user}@${host}/${name}":
-    host            => $host,
-    port            => $port,
-    authorized_user => $authorized_user,
-    authorized_pass => $authorized_pass,
-    privileges      => $grant,
-    provider        => 'mysql',
-    require         => Database_user["${user}@${host}"],
+    privileges => $grant,
+    provider   => 'mysql',
+    require    => Database_user["${user}@${host}"],
   }
 
   $refresh = ! $enforce_sql

--- a/deployment/puppet/mysql/manifests/server/monitor.pp
+++ b/deployment/puppet/mysql/manifests/server/monitor.pp
@@ -1,29 +1,17 @@
 class mysql::server::monitor (
   $mysql_monitor_username,
   $mysql_monitor_password,
-  $mysql_monitor_hostname,
-  $host = false,
-  $port = false,
-  $authorized_user = false,
-  $authorized_pass = false,
+  $mysql_monitor_hostname
 ) {
 
   Class['mysql::server'] -> Class['mysql::server::monitor']
 
   database_user{ "${mysql_monitor_username}@${mysql_monitor_hostname}":
-    host            => $host,
-    port            => $port,
-    authorized_user => $authorized_user,
-    authorized_pass => $authorized_pass,
     password_hash => mysql_password($mysql_monitor_password),
     ensure        => present,
   }
 
   database_grant { "${mysql_monitor_username}@${mysql_monitor_hostname}":
-    host            => $host,
-    port            => $port,
-    authorized_user => $authorized_user,
-    authorized_pass => $authorized_pass,
     privileges => [ 'process_priv', 'super_priv' ],
     require    => Mysql_user["${mysql_monitor_username}@${mysql_monitor_hostname}"],
   }


### PR DESCRIPTION
Undo all changes were made to mysql module since 3.0.1 release - it looks broken in develop branch
(err: Could not load downloaded file /var/lib/puppet/lib/puppet/type/database.rb: Could not autoload /var/lib/puppet/lib/puppet/provider/database/mysql.rb: /var/lib/puppet/lib/puppet/provider/database/mysql.rb:7: syntax error, unexpected '))
