### PR TITLE
[FUEL-761] Support call rspec tests using rake spec

### DIFF
--- a/deployment/puppet/inifile/Rakefile
+++ b/deployment/puppet/inifile/Rakefile
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/rake_tasks'


### PR DESCRIPTION
Need for unification of tests run call (`rake spec` instead of `rspec spec` for this module) 
