### PR TITLE
Fix level NOTSET and root handlers for logging confs

### DIFF
--- a/deployment/puppet/cinder/templates/logging.conf.erb
+++ b/deployment/puppet/cinder/templates/logging.conf.erb
@@ -9,9 +9,10 @@ keys = production,devel
 keys = normal,debug
 
 [logger_root]
-level = DEBUG
+level = NOTSET
 handlers = production
-qualname = cinder
+propagate = 1
+#qualname = cinder
 
 [formatter_debug]
 format = cinder-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s

--- a/deployment/puppet/glance/templates/logging.conf.erb
+++ b/deployment/puppet/glance/templates/logging.conf.erb
@@ -9,9 +9,10 @@ keys = production,devel
 keys = normal,debug
 
 [logger_root]
-level = DEBUG
+level = NOTSET
 handlers = production
-qualname = glance
+propagate = 1
+#qualname = glance
 
 [formatter_debug]
 format = glance-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s

--- a/deployment/puppet/horizon/templates/local_settings.py.erb
+++ b/deployment/puppet/horizon/templates/local_settings.py.erb
@@ -108,24 +108,24 @@ LOGGING = {
         },
         'handlers': {
             'null': {
-                'level': 'DEBUG',
+                'level': '<%= log_level %>',
                 'class': 'django.utils.log.NullHandler',
                 'formatter': 'debug'
                 },
             'console': {
                 # Set the level to "DEBUG" for verbose output logging.
-                'level': 'DEBUG',
+                'level': '<%= log_level %>',
                 'class': 'logging.StreamHandler',
                 'formatter': 'debug'
                 },
             'file': {
-                'level': 'DEBUG',
+                'level': '<%= log_level %>',
                 'class': 'logging.FileHandler',
                 'filename': '<%= scope.lookupvar("horizon::params::logdir") %>/horizon.log',
                 'formatter': 'normal'
                 },
             'syslog': {
-                'level': 'DEBUG',
+                'level': '<%= log_level %>',
                 'facility': 'local1',
                 'class': 'logging.handlers.SysLogHandler',
                 'address': '/dev/log',
@@ -137,49 +137,49 @@ LOGGING = {
             # logs from any application in this project will go here.
             '': {
                 'handlers':<% if use_syslog -%> ['syslog']<% else -%> ['file']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': True
                 },
             # Logging from django.db.backends is VERY verbose, send to null
             # by default.
             'django.db.backends': {
                 'handlers':<% if django_debug=='False' and use_syslog -%> ['syslog']<% else -%> ['null']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': False
                 },
             'horizon': {
                 'handlers':<% if use_syslog -%> ['syslog']<% else -%> ['file']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': False
             },
             'openstack_dashboard': {
                 'handlers':<% if use_syslog -%> ['syslog']<% else -%> ['file']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': False
             },
             'novaclient': {
                 'handlers':<% if use_syslog -%> ['syslog']<% else -%> ['file']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': False
             },
            'glanceclient': {
                 'handlers':<% if use_syslog -%> ['syslog']<% else -%> ['file']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': False
             },
             'keystoneclient': {
                 'handlers':<% if use_syslog -%> ['syslog']<% else -%> ['file']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': False
             },
             'quantumclient': {
                 'handlers':<% if use_syslog -%> ['syslog']<% else -%> ['file']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': False
             },
             'nose.plugins.manager': {
                 'handlers':<% if use_syslog -%> ['syslog']<% else -%> ['file']<% end -%>,
-                'level': '<%= log_level %>',
+                'level': 'NOTSET',
                 'propagate': False
             }
         }

--- a/deployment/puppet/keystone/templates/logging.conf.erb
+++ b/deployment/puppet/keystone/templates/logging.conf.erb
@@ -9,9 +9,10 @@ keys = production,devel
 keys = normal,debug
 
 [logger_root]
-level = DEBUG
+level = NOTSET
 handlers = production
-qualname = keystone
+propagate = 1
+#qualname = keystone
 
 [formatter_debug]
 format = keystone-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s

--- a/deployment/puppet/nova/templates/logging.conf.erb
+++ b/deployment/puppet/nova/templates/logging.conf.erb
@@ -9,9 +9,10 @@ keys = production,devel
 keys = normal,debug
 
 [logger_root]
-level = DEBUG
+level = NOTSET
 handlers = production
-qualname = nova
+propagate = 1
+#qualname = nova
 
 [formatter_debug]
 format = nova-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -9,9 +9,10 @@ keys = production,devel
 keys = normal,debug
 
 [logger_root]
-level = DEBUG
+level = NOTSET
 handlers = production
-qualname = quantum
+propagate = 1
+#qualname = quantum
 
 [formatter_debug]
 format = quantum-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s


### PR DESCRIPTION
level NOTSET, propagate = 1, and empty qualname would ensure all
qualnames and all messages would match the root logger

Signed-off-by: Bogdan Dobrelya bogdando@mail.ru
