### PR TITLE
Minor fixes for syslog in HA examples and minsize for logrotate

### DIFF
--- a/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
@@ -377,7 +377,7 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
-$use_syslog = false
+$use_syslog = true
 # Default log level would have been used, if non verbose and non debug
 $syslog_log_level             = 'ERROR'
 # Syslog facilities for main openstack services, choose any, may overlap if needed

--- a/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
@@ -401,6 +401,7 @@ if $use_syslog {
     # keep four weekly log rotations, force rotate if 300M size have exceeded
     rotation       => 'weekly',
     keep           => '4',
+    # should be > 30M
     limitsize      => '300M',
     # remote servers to send logs to
     rservers       => [{'remote_type'=>'udp', 'server'=>'master', 'port'=>'514'},],

--- a/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
@@ -395,7 +395,7 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
-$use_syslog = false
+$use_syslog = true
 # Default log level would have been used, if non verbose and non debug
 $syslog_log_level             = 'ERROR'
 # Syslog facilities for main openstack services, choose any, may overlap if needed

--- a/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
@@ -419,6 +419,7 @@ if $use_syslog {
     # keep four weekly log rotations, force rotate if 300M size have exceeded
     rotation       => 'weekly',
     keep           => '4',
+    # should be > 30M
     limitsize      => '300M',
     # remote servers to send logs to
     rservers       => [{'remote_type'=>'udp', 'server'=>'master', 'port'=>'514'},],

--- a/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
@@ -441,6 +441,7 @@ if $use_syslog {
     # keep four weekly log rotations, force rotate if 300M size have exceeded
     rotation       => 'weekly',
     keep           => '4',
+    # should be > 30M
     limitsize      => '300M',
     # remote servers to send logs to
     rservers       => [{'remote_type'=>'udp', 'server'=>'master', 'port'=>'514'},],

--- a/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
@@ -417,7 +417,7 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
-$use_syslog = false
+$use_syslog = true
 # Default log level would have been used, if non verbose and non debug
 $syslog_log_level             = 'ERROR'
 # Syslog facilities for main openstack services, choose any, may overlap if needed

--- a/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
@@ -364,7 +364,7 @@ $swift_loopback = false
 
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
-$use_syslog = false
+$use_syslog = true
 # Default log level would have been used, if non verbose and non debug
 $syslog_log_level             = 'ERROR'
 # Syslog facilities for main openstack services, choose any, may overlap if needed

--- a/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
@@ -388,6 +388,7 @@ if $use_syslog {
     # keep four weekly log rotations, force rotate if 300M size have exceeded
     rotation       => 'weekly',
     keep           => '4',
+    # should be > 30M
     limitsize      => '300M',
     # remote servers to send logs to
     rservers       => [{'remote_type'=>'udp', 'server'=>'master', 'port'=>'514'},],

--- a/deployment/puppet/openstack/examples/site_openstack_simple.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_simple.pp
@@ -330,6 +330,7 @@ if $use_syslog {
     # keep four weekly log rotations, force rotate if 300M size have exceeded
     rotation       => 'weekly',
     keep           => '4',
+    # should be > 30M
     limitsize      => '300M',
     # remote servers to send logs to
     rservers       => [{'remote_type'=>'udp', 'server'=>'master', 'port'=>'514'},],

--- a/deployment/puppet/openstack/examples/site_openstack_single.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_single.pp
@@ -304,6 +304,7 @@ if $use_syslog {
     # keep four weekly log rotations, force rotate if 300M size have exceeded
     rotation       => 'weekly',
     keep           => '4',
+    # should be > 30M
     limitsize      => '300M',
     # remote servers to send logs to
     rservers       => [{'remote_type'=>'udp', 'server'=>'master', 'port'=>'514'},],

--- a/deployment/puppet/openstack/templates/10-fuel.conf.erb
+++ b/deployment/puppet/openstack/templates/10-fuel.conf.erb
@@ -3,9 +3,11 @@
 "/var/log/auth.log" "/var/log/user.log" "var/log/mail.log"
 "/var/log/cron.log" "/var/log/dashboard.log" "/var/log/ha.log"
 {
-# This file is used for daily log rotations, do not use (min)size options here
+# This file is used for daily log rotations, do not use size options here
   sharedscripts
   <%= @rotation %>
+  # rotate only if 30M size or bigger
+  minsize 30M
   # truncate file, do not delete & recreate
   copytruncate
   # keep logs for <%= @keep %> rotations

--- a/iso/bootstrap_admin_node.sh
+++ b/iso/bootstrap_admin_node.sh
@@ -34,6 +34,7 @@ puppet apply -e "
       log_auth_local => true,
       rotation       => 'daily',
       keep           => '7',
+      # should be > 30M
       limitsize      => '100M',
       port           => '514',
       proto          => 'udp',


### PR DESCRIPTION
- for ha examples, set syslog as default mode
- logrotate minimum log file size hardcoded as 30M to prevent small files from rotatation
