### PR TITLE
Fix syslog log_level and tag prefix for swift

### DIFF
--- a/deployment/puppet/swift/manifests/proxy.pp
+++ b/deployment/puppet/swift/manifests/proxy.pp
@@ -74,10 +74,10 @@ class swift::proxy(
   }
   if $::osfamily == "Debian"
   {
-    package { 'swift-plugin-s3': 
-    ensure => present, 
+    package { 'swift-plugin-s3':
+    ensure => present,
     before=>Package['swift-proxy']
-    } 
+    }
   }
 
   package { 'swift-proxy':

--- a/deployment/puppet/swift/templates/account-server.conf.erb
+++ b/deployment/puppet/swift/templates/account-server.conf.erb
@@ -5,6 +5,14 @@ bind_port = <%= bind_port %>
 mount_check = <%= mount_check %>
 user = <%= user %>
 log_facility = LOG_SYSLOG
+<% if scope.lookupvar('::debug') then -%>
+log_level = DEBUG
+<% elsif scope.lookupvar('::verbose') then -%>
+log_level = INFO
+<% else -%>
+log_level = <%= scope.lookupvar('::syslog_log_level') %>
+<% end -%>
+log_name = swift-account-server
 workers = <%= workers %>
 
 [pipeline:main]

--- a/deployment/puppet/swift/templates/container-server.conf.erb
+++ b/deployment/puppet/swift/templates/container-server.conf.erb
@@ -5,6 +5,14 @@ bind_port = <%= bind_port %>
 mount_check = <%= mount_check %>
 user = <%= user %>
 log_facility = LOG_SYSLOG
+<% if scope.lookupvar('::debug') then -%>
+log_level = DEBUG
+<% elsif scope.lookupvar('::verbose') then -%>
+log_level = INFO
+<% else -%>
+log_level = <%= scope.lookupvar('::syslog_log_level') %>
+<% end -%>
+log_name = swift-container-server
 workers = <%= workers %>
 
 [pipeline:main]

--- a/deployment/puppet/swift/templates/object-server.conf.erb
+++ b/deployment/puppet/swift/templates/object-server.conf.erb
@@ -5,6 +5,14 @@ bind_port = <%= bind_port %>
 mount_check = <%= mount_check %>
 user = <%= user %>
 log_facility = LOG_SYSLOG
+<% if scope.lookupvar('::debug') then -%>
+log_level = DEBUG
+<% elsif scope.lookupvar('::verbose') then -%>
+log_level = INFO
+<% else -%>
+log_level = <%= scope.lookupvar('::syslog_log_level') %>
+<% end -%>
+log_name = swift-object-server
 workers = <%= workers %>
 
 [pipeline:main]

--- a/deployment/puppet/swift/templates/proxy-server.conf.erb
+++ b/deployment/puppet/swift/templates/proxy-server.conf.erb
@@ -5,6 +5,14 @@ bind_ip = <%= proxy_local_net_ip %>
 bind_port = <%= port %>
 workers = <%= workers %>
 log_facility = LOG_SYSLOG
+<% if scope.lookupvar('::debug') then -%>
+log_level = DEBUG
+<% elsif scope.lookupvar('::verbose') then -%>
+log_level = INFO
+<% else -%>
+log_level = <%= scope.lookupvar('::syslog_log_level') %>
+<% end -%>
+log_name = swift-proxy-server
 user = swift
 
 [pipeline:main]


### PR DESCRIPTION
- Use top scope values for debug,verbose,syslog_log_level for swift as well.
- Add swift- prefix for remote log file names
