### PR TITLE
Override yum provider core plugin for puppet

### DIFF
--- a/deployment/puppet/puppet/lib/puppet/provider/package/yum.rb
+++ b/deployment/puppet/puppet/lib/puppet/provider/package/yum.rb
@@ -1,0 +1,121 @@
+require 'puppet/util/package'
+
+Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
+  desc "Support via `yum`."
+
+  has_feature :versionable
+
+  commands :yum => "yum", :rpm => "rpm", :python => "python"
+
+  YUMHELPER = File::join(File::dirname(__FILE__), "yumhelper.py")
+
+  attr_accessor :latest_info
+
+  if command('rpm')
+    confine :true => begin
+      rpm('--version')
+      rescue Puppet::ExecutionFailure
+        false
+      else
+        true
+      end
+  end
+
+  defaultfor :operatingsystem => [:fedora, :centos, :redhat]
+
+  def self.prefetch(packages)
+    raise Puppet::Error, "The yum provider can only be used as root" if Process.euid != 0
+    super
+    return unless packages.detect { |name, package| package.should(:ensure) == :latest }
+
+    # collect our 'latest' info
+    updates = {}
+    python(YUMHELPER).each_line do |l|
+      l.chomp!
+      next if l.empty?
+      if l[0,4] == "_pkg"
+        hash = nevra_to_hash(l[5..-1])
+        [hash[:name], "#{hash[:name]}.#{hash[:arch]}"].each  do |n|
+          updates[n] ||= []
+          updates[n] << hash
+        end
+      end
+    end
+
+    # Add our 'latest' info to the providers.
+    packages.each do |name, package|
+      if info = updates[package[:name]]
+        package.provider.latest_info = info[0]
+      end
+    end
+  end
+
+  def install
+    should = @resource.should(:ensure)
+    self.debug "Ensuring => #{should}"
+    wanted = @resource[:name]
+    operation = :install
+    tries = 1
+    limiter = 0
+
+    case should
+    when true, false, Symbol
+      # pass
+      should = nil
+    else
+      # Add the package version
+      wanted += "-#{should}"
+      is = self.query
+      if is && Puppet::Util::Package.versioncmp(should, is[:ensure]) < 0
+        self.debug "Downgrading package #{@resource[:name]} from version #{is[:ensure]} to #{should}"
+        operation = :downgrade
+      end
+    end
+
+    begin
+      limiter += 1
+      yum "-d", "0", "-e", "0", "-y", operation, wanted
+    rescue Puppet::ExecutionFailure => error
+      debug("Got error while operation:#{operation}, wanted:#{wanted}:\n#{error}")
+      if limiter <= tries
+        debug("Cleaning yum cache and retrying operation, try #{limiter} of #{tries}...")
+        yum "clean", "expire-cache"
+        #yum "history", "redo", "last"
+        retry
+      else
+        raise Puppet::Error, "Could not complete an operation:#{operation}, wanted:#{wanted}:\n#{error}"
+      end
+    end
+
+    is = self.query
+    raise Puppet::Error, "Could not find package #{self.name}" unless is
+
+    # FIXME: Should we raise an exception even if should == :latest
+    # and yum updated us to a version other than @param_hash[:ensure] ?
+    raise Puppet::Error, "Failed to update to version #{should}, got version #{is[:ensure]} instead" if should && should != is[:ensure]
+  end
+
+  # What's the latest package version available?
+  def latest
+    upd = latest_info
+    unless upd.nil?
+      # FIXME: there could be more than one update for a package
+      # because of multiarch
+      return "#{upd[:epoch]}:#{upd[:version]}-#{upd[:release]}"
+    else
+      # Yum didn't find updates, pretend the current
+      # version is the latest
+      raise Puppet::DevError, "Tried to get latest on a missing package" if properties[:ensure] == :absent
+      return properties[:ensure]
+    end
+  end
+
+  def update
+    # Install in yum can be used for update, too
+    self.install
+  end
+
+  def purge
+    yum "-y", :erase, @resource[:name]
+  end
+end

--- a/deployment/puppet/puppet/lib/puppet/provider/package/yumhelper.py
+++ b/deployment/puppet/puppet/lib/puppet/provider/package/yumhelper.py
@@ -1,0 +1,129 @@
+# Python helper script to query for the packages that have
+# pending updates. Called by the yum package provider
+#
+# (C) 2007 Red Hat Inc.
+# David Lutterkort <dlutter @redhat.com>
+
+import sys
+import string
+import re
+
+# this maintains compatibility with really old platforms with python 1.x
+from os import popen, WEXITSTATUS
+
+# Try to use the yum libraries by default, but shell out to the yum executable
+# if they are not present (i.e. yum <= 2.0). This is only required for RHEL3
+# and earlier that do not support later versions of Yum. Once RHEL3 is EOL,
+# shell_out() and related code can be removed.
+try:
+    import yum
+except ImportError:
+    useyumlib = 0
+else:
+    useyumlib = 1
+
+OVERRIDE_OPTS = {
+    'debuglevel': 0,
+    'errorlevel': 0,
+    'logfile': '/dev/null'
+}
+
+def pkg_lists(my):
+    my.doConfigSetup()
+
+    for k in OVERRIDE_OPTS.keys():
+        if hasattr(my.conf, k):
+            setattr(my.conf, k, OVERRIDE_OPTS[k])
+        else:
+            my.conf.setConfigOption(k, OVERRIDE_OPTS[k])
+
+    my.doTsSetup()
+    my.doRpmDBSetup()
+
+    # Yum 2.2/2.3 python libraries require a couple of extra function calls to setup package sacks.
+    # They also don't have a __version__ attribute
+    try:
+        yumver = yum.__version__
+    except AttributeError:
+        my.doRepoSetup()
+        my.doSackSetup()
+
+    return my.doPackageLists('updates')
+
+def shell_out():
+    try:
+        p = popen("/usr/bin/env yum check-update 2>&1")
+        output = p.readlines()
+        rc = p.close()
+
+        if rc is not None:
+            # None represents exit code of 0, otherwise the exit code is in the
+            # format returned by wait(). Exit code of 100 from yum represents
+            # updates available.
+            if WEXITSTATUS(rc) != 100:
+                return WEXITSTATUS(rc)
+        else:
+            # Exit code is None (0), no updates waiting so don't both parsing output
+            return 0
+
+        # Yum prints a line of hyphens (old versions) or a blank line between
+        # headers and package data, so skip everything before them
+        skipheaders = 0
+        for line in output:
+            if not skipheaders:
+                if re.compile("^((-){80}|)$").search(line):
+                    skipheaders = 1
+                continue
+
+            # Skip any blank lines
+            if re.compile("^[ \t]*$").search(line):
+                continue
+
+            # Format is:
+            # Yum 1.x: name arch (epoch:)?version
+            # Yum 2.0: name arch (epoch:)?version repo
+            # epoch is optional if 0
+
+            p = string.split(line)
+            pname = p[0]
+            parch = p[1]
+            pevr = p[2]
+
+            # Separate out epoch:version-release
+            evr_re = re.compile("^(\d:)?(\S+)-(\S+)$")
+            evr = evr_re.match(pevr)
+
+            pepoch = ""
+            if evr.group(1) is None:
+                pepoch = "0"
+            else:
+                pepoch = evr.group(1).replace(":", "")
+            pversion = evr.group(2)
+            prelease = evr.group(3)
+
+            print "_pkg", pname, pepoch, pversion, prelease, parch
+
+        return 0
+    except:
+        print sys.exc_info()[0]
+        return 1
+
+if useyumlib:
+    try:
+        try:
+            my = yum.YumBase()
+            ypl = pkg_lists(my)
+            for pkg in ypl.updates:
+                print "_pkg %s %s %s %s %s" % (pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch)
+        finally:
+            my.closeRpmDB()
+    except IOError, e:
+        print "_err IOError %d %s" % (e.errno, e)
+        sys.exit(1)
+    except AttributeError, e:
+        # catch yumlib errors in buggy 2.x versions of yum
+        print "_err AttributeError %s" % e
+        sys.exit(1)
+else:
+    rc = shell_out()
+    sys.exit(rc)


### PR DESCRIPTION
Ensures yum provider would have expired metadata cache
and redo last, if operation had failed
scope: puppet 2.7.19

Implements: #FUEL-632
