### PR TITLE
Fix keystone and quantum logs

### DIFF
--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -19,7 +19,7 @@
 #     Defaults to False.
 #   [use_syslog] Rather or not keystone should log to syslog. Optional.
 #     Defaults to False.
-#   [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option 
+#   [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option
 #     wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
 #   [syslog_log_level] logging level for non verbose and non debug mode. Optional.
 #   [catalog_type] Type of catalog that keystone uses to store endpoints,services. Optional.
@@ -62,6 +62,8 @@ class keystone(
   $use_syslog          = false,
   $syslog_log_facility = 'LOCAL7',
   $syslog_log_level = 'WARNING',
+  $log_dir             = '/var/log/keystone',
+  $log_file            = 'keystone.log',
   $catalog_type        = 'sql',
   $token_format        = 'UUID',
 #  $token_format        = 'PKI',
@@ -106,6 +108,7 @@ class keystone(
     keystone_config {
      'DEFAULT/log_config': ensure => absent;
      'DEFAULT/log_file': value => $log_file;
+     'DEFAULT/log_dir': value => $log_dir;
     }
   }
 
@@ -256,7 +259,7 @@ class keystone(
       notify  => Service['keystone'],
     }
 
-    # keystone-manage pki_setup Should be run as the same system user that will be running the Keystone service to ensure 
+    # keystone-manage pki_setup Should be run as the same system user that will be running the Keystone service to ensure
     # proper ownership for the private key file and the associated certificates
     exec { 'keystone-manage pki_setup':
       path        => '/usr/bin',

--- a/deployment/puppet/openstack/templates/20-fuel.conf.erb
+++ b/deployment/puppet/openstack/templates/20-fuel.conf.erb
@@ -1,6 +1,6 @@
 "/var/log/*-all.log" "/var/log/remote/*/*log"
 "/var/log/kern.log" "/var/log/debug" "/var/log/syslog"
-"/var/log/dashboard.log" "/var/log/ha.log"
+"/var/log/dashboard.log" "/var/log/ha.log" "/var/log/quantum/*.log"
 # This file is used for hourly log rotations, use (min)size options here
 {
   sharedscripts

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -57,6 +57,7 @@ class = StreamHandler
 formatter = debug
 args = (sys.stdout,)
 
+<% if @debug then -%>
 [handler_quantum]
 class = logging.FileHandler
 args = ('/var/log/quantum/all.log',)
@@ -105,3 +106,4 @@ qualname = quantum.agent.metadata
 class = logging.FileHandler
 args = ('/var/log/quantum/metadata.log',)
 formatter = default
+<% end -%>

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -3,12 +3,7 @@
 keys = root, l3agent, ovsagent, dhcpagent, metadata
 
 [handlers]
-keys = production,devel, quantum, l3agent, ovsagent, dhcpagent, metadata
-
-[logger_root]
-level = NOTSET
-handlers = quantum
-propagate = 1
+keys = production,devel, l3agent, ovsagent, dhcpagent, metadata
 
 <% else -%>
 [loggers]
@@ -58,12 +53,6 @@ formatter = debug
 args = (sys.stdout,)
 
 <% if @debug then -%>
-[handler_quantum]
-class = logging.FileHandler
-args = ('/var/log/quantum/all.log',)
-formatter = default
-
-
 [logger_l3agent]
 handlers = l3agent
 level=NOTSET


### PR DESCRIPTION
- quantum: logging config handlers & loggers should be described the same way, as were declared above.
- quantum: new log files for debug should be added to hourly rotation as well
- keystone: if non syslog mode, keystone.conf should have had log_dir & log_file options configured
