### PR TITLE
Fix alllogs

### DIFF
--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -4,7 +4,7 @@
 # $osapi_volume_extension = cinder.api.openstack.volume.contrib.standard_extensions
 # $root_helper = sudo /usr/local/bin/cinder-rootwrap /etc/cinder/rootwrap.conf
 # $use_syslog = Rather or not service should log to syslog. Optional.
-# $syslog_log_facility = Facility for syslog, if used. Optional. Note: duplicating conf option 
+# $syslog_log_facility = Facility for syslog, if used. Optional. Note: duplicating conf option
 #       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
 # $syslog_log_level = logging level for non verbose and non debug mode. Optional.
 
@@ -54,7 +54,7 @@ class cinder::base (
     ensure  => present,
     owner   => 'cinder',
     group   => 'cinder',
-    mode    => '0644',
+    mode    => '0640',
     require => Package['cinder'],
   }
 
@@ -68,9 +68,6 @@ if $use_syslog {
     content => template('cinder/logging.conf.erb'),
     path => "/etc/cinder/logging.conf",
     require => File[$::cinder::params::cinder_conf],
-  }
-  file { "cinder-all.log":
-    path => "/var/log/cinder-all.log",
   }
 
   # We must notify services to apply new logging rules

--- a/deployment/puppet/glance/manifests/init.pp
+++ b/deployment/puppet/glance/manifests/init.pp
@@ -12,16 +12,13 @@ class glance(
     ensure  => present,
     owner   => 'glance',
     group   => 'glance',
-    mode    => '0644',
+    mode    => '0640',
     require => Package['glance'],
   }
 
   file { '/etc/glance/':
     ensure  => directory,
     mode    => '0770',
-  }
-  file { "glance-all.log":
-    path => "/var/log/glance-all.log",
   }
 
   group {'glance': gid=> 161, ensure=>present, system=>true}

--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -84,7 +84,7 @@ class keystone(
     ensure  => present,
     owner   => 'keystone',
     group   => 'keystone',
-    mode    => '0644',
+    mode    => '0640',
     require => Package['keystone'],
   }
 
@@ -100,9 +100,6 @@ class keystone(
       require => File['/etc/keystone'],
       # We must notify service for new logging rules
       notify => Service['keystone'],
-    }
-    file { "keystone-all.log":
-      path => "/var/log/keystone-all.log",
     }
   } else  {
     keystone_config {

--- a/deployment/puppet/nova/manifests/init.pp
+++ b/deployment/puppet/nova/manifests/init.pp
@@ -34,7 +34,7 @@
 # $rabbit_nodes = ['node001', 'node002', 'node003']
 # add rabbit nodes hostname
 # [use_syslog] Rather or not service should log to syslog. Optional.
-# [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option 
+# [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option
 #       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
 # [syslog_log_level] logging level for non verbose and non debug mode. Optional.
 #
@@ -157,7 +157,7 @@ class nova(
     ensure  => present,
     owner   => 'nova',
     group   => 'nova',
-    mode    => '0644',
+    mode    => '0640',
     require => Package['nova-common'],
   }
 
@@ -182,9 +182,6 @@ file {"nova-logging.conf":
   content => template('nova/logging.conf.erb'),
   path => "/etc/nova/logging.conf",
   require => File[$logdir],
-}
-file { "nova-all.log":
-  path => "/var/log/nova-all.log",
 }
 
 # We must notify services to apply new logging rules

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -180,7 +180,7 @@ class quantum (
       content => template('quantum/logging.conf.erb'),
       path  => "/etc/quantum/logging.conf",
       owner => "root",
-      group => "root",
+      group => "quantum",
       mode  => 640,
     }
 

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -181,10 +181,7 @@ class quantum (
       path  => "/etc/quantum/logging.conf",
       owner => "root",
       group => "root",
-      mode  => 644,
-    }
-    file { "quantum-all.log":
-      path => "/var/log/quantum-all.log",
+      mode  => 640,
     }
 
     # We must setup logging before start services under pacemaker


### PR DESCRIPTION
- fix /var/log/*-all.log files: thus managed by rsyslog, no need to pre-create and chown with puppet anymore
- fix access mode defaults for some openstack services' file resources from 644 to 640 to ensure config files won't be world readable
