### PR TITLE
Fix 835

### DIFF
--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -4,8 +4,7 @@
 # $osapi_volume_extension = cinder.api.openstack.volume.contrib.standard_extensions
 # $root_helper = sudo /usr/local/bin/cinder-rootwrap /etc/cinder/rootwrap.conf
 # $use_syslog = Rather or not service should log to syslog. Optional.
-# $syslog_log_facility = Facility for syslog, if used. Optional. Note: duplicating conf option 
-#       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
+# $syslog_log_facility = Facility for syslog, if used. Optional.
 # $syslog_log_level = logging level for non verbose and non debug mode. Optional.
 
 class cinder::base (
@@ -51,11 +50,19 @@ class cinder::base (
     require => Package['cinder'],
   }
 
-if $use_syslog {
+  cinder_config {
+    'DEFAULT/log_file':   ensure=> absent;
+    'DEFAULT/log_dir':    ensure=> absent;
+    'DEFAULT/logfile':   ensure=> absent;
+    'DEFAULT/logdir':    ensure=> absent;
+  }
+
+if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
   cinder_config {
     'DEFAULT/log_config': value => "/etc/cinder/logging.conf";
-    'DEFAULT/log_file': ensure=> absent;
-    'DEFAULT/logdir': ensure=> absent;
+    'DEFAULT/use_stderr': ensure=> absent;
+    'DEFAULT/use_syslog': value => true;
+    'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
   }
   file { "cinder-logging.conf":
     content => template('cinder/logging.conf.erb'),
@@ -65,16 +72,26 @@ if $use_syslog {
   file { "cinder-all.log":
     path => "/var/log/cinder-all.log",
   }
-
+}
+else {
+  # logging for agents grabbing from stderr
+  cinder_config {
+    'DEFAULT/log_config': ensure=> absent;
+    'DEFAULT/use_syslog': ensure=> absent;
+    'DEFAULT/syslog_log_facility': ensure=> absent;
+    'DEFAULT/use_stderr': value => true;
+  }
+  # might be used for stdout logging instead, if configured
+  file { "cinder-logging.conf":
+    content => template('cinder/logging.conf-nosyslog.erb'),
+    path => "/etc/cinder/logging.conf",
+    require => File[$::cinder::params::cinder_conf],
+  }
+}
   # We must notify services to apply new logging rules
   File['cinder-logging.conf'] ~> Service<| title == 'cinder-api' |>
   File['cinder-logging.conf'] ~> Service<| title == 'cinder-volume' |>
   File['cinder-logging.conf'] ~> Service<| title == 'cinder-scheduler' |>
-
-}
-else {
-	cinder_config {'DEFAULT/log_config': ensure=>absent;}
-}
 
   file { $::cinder::params::cinder_conf: }
   file { $::cinder::params::cinder_paste_api_ini: }
@@ -107,7 +124,6 @@ else {
     'DEFAULT/debug':               value => $debug;
     'DEFAULT/verbose':             value => $verbose;
     'DEFAULT/api_paste_config':    value => '/etc/cinder/api-paste.ini';
-    'DEFAULT/use_syslog':          value => $use_syslog;
   }
   exec { 'cinder-manage db_sync':
     command     => $::cinder::params::db_sync_command,

--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -50,16 +50,13 @@ class cinder::base (
     require => Package['cinder'],
   }
 
+if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
   cinder_config {
+    'DEFAULT/log_config': value => "/etc/cinder/logging.conf";
     'DEFAULT/log_file':   ensure=> absent;
     'DEFAULT/log_dir':    ensure=> absent;
     'DEFAULT/logfile':   ensure=> absent;
     'DEFAULT/logdir':    ensure=> absent;
-  }
-
-if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
-  cinder_config {
-    'DEFAULT/log_config': value => "/etc/cinder/logging.conf";
     'DEFAULT/use_stderr': ensure=> absent;
     'DEFAULT/use_syslog': value => true;
     'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -74,12 +71,15 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
   }
 }
 else {
-  # logging for agents grabbing from stderr
   cinder_config {
     'DEFAULT/log_config': ensure=> absent;
     'DEFAULT/use_syslog': ensure=> absent;
     'DEFAULT/syslog_log_facility': ensure=> absent;
-    'DEFAULT/use_stderr': value => true;
+    'DEFAULT/use_stderr': ensure=> absent;
+    'DEFAULT/logging_context_format_string':
+     value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+    'DEFAULT/logging_default_format_string':
+     value => '%(asctime)s %(levelname)s %(name)s [-] %(instance)s %(message)s';
   }
   # might be used for stdout logging instead, if configured
   file { "cinder-logging.conf":

--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -22,6 +22,7 @@ class cinder::base (
   $use_syslog             = false,
   $syslog_log_facility    = "LOCAL3",
   $syslog_log_level = 'WARNING',
+  $log_dir                = '/var/log/cinder',
 ) {
 
   include cinder::params
@@ -76,6 +77,7 @@ else {
     'DEFAULT/use_syslog': ensure=> absent;
     'DEFAULT/syslog_log_facility': ensure=> absent;
     'DEFAULT/use_stderr': ensure=> absent;
+    'DEFAULT/logdir':value=> $log_dir;
     'DEFAULT/logging_context_format_string':
      value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
     'DEFAULT/logging_default_format_string':

--- a/deployment/puppet/cinder/templates/logging.conf-nosyslog.erb
+++ b/deployment/puppet/cinder/templates/logging.conf-nosyslog.erb
@@ -1,0 +1,24 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = root
+
+[formatters]
+keys = default
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s
+
+
+[logger_root]
+level=NOTSET
+handlers = root
+propagate = 1
+
+
+[handler_root]
+class = StreamHandler
+level=NOTSET
+formatter = default
+args = (sys.stdout,)

--- a/deployment/puppet/cinder/templates/logging.conf.erb
+++ b/deployment/puppet/cinder/templates/logging.conf.erb
@@ -13,13 +13,12 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = cinder-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = cinder-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = cinder-%(name)s %(levelname)s: %(module)s %(message)s
+format = cinder-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/cinder-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>

--- a/deployment/puppet/cinder/templates/logging.conf.erb
+++ b/deployment/puppet/cinder/templates/logging.conf.erb
@@ -1,24 +1,22 @@
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
 [formatters]
 keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = cinder
 
 [formatter_debug]
-format = cinder-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = cinder-%(name)s: %(levelname)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/cinder-all.log
@@ -26,16 +24,41 @@ format = cinder-%(name)s: %(levelname)s %(message)s
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
 formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
 args = (sys.stdout,)

--- a/deployment/puppet/cinder/templates/logging.conf.erb
+++ b/deployment/puppet/cinder/templates/logging.conf.erb
@@ -13,10 +13,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = cinder-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = cinder-%(name)s %(levelname)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/glance/manifests/api.pp
+++ b/deployment/puppet/glance/manifests/api.pp
@@ -111,6 +111,7 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
    'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/log_file':value=> $log_file;
    'DEFAULT/logging_context_format_string':
     value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
    'DEFAULT/logging_default_format_string':

--- a/deployment/puppet/glance/manifests/api.pp
+++ b/deployment/puppet/glance/manifests/api.pp
@@ -88,16 +88,13 @@ class glance::api(
     fail("Invalid db connection ${sql_connection}")
   }
 
+if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
  glance_api_config {
+   'DEFAULT/log_config': value => "/etc/glance/logging.conf";
    'DEFAULT/log_file': ensure=> absent;
    'DEFAULT/log_dir': ensure=> absent;
    'DEFAULT/logfile':   ensure=> absent;
    'DEFAULT/logdir':    ensure=> absent;
- }
-
-if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
- glance_api_config {
-   'DEFAULT/log_config': value => "/etc/glance/logging.conf";
    'DEFAULT/use_stderr':  ensure=> absent;
    'DEFAULT/use_syslog':  value => true;
    'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -110,11 +107,14 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
  }
 } else {
  glance_api_config {
-   # logging for agents grabbing from stderr
    'DEFAULT/log_config': ensure=> absent;
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
-   'DEFAULT/use_stderr': value => true;
+   'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/logging_context_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+   'DEFAULT/logging_default_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [-] %(instance)s %(message)s';
  }
  # might be used for stdout logging instead, if configured
    if !defined(File["glance-logging.conf"]) {

--- a/deployment/puppet/glance/manifests/registry.pp
+++ b/deployment/puppet/glance/manifests/registry.pp
@@ -54,6 +54,7 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
    'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/log_file':value=>$log_file;
    'DEFAULT/logging_context_format_string':
     value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
    'DEFAULT/logging_default_format_string':

--- a/deployment/puppet/glance/manifests/registry.pp
+++ b/deployment/puppet/glance/manifests/registry.pp
@@ -31,16 +31,13 @@ File {
   require => Class['glance']
 }
 
-glance_registry_config {
+if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
+ glance_registry_config {
+   'DEFAULT/log_config': value => "/etc/glance/logging.conf";
    'DEFAULT/log_file': ensure=> absent;
    'DEFAULT/log_dir': ensure=> absent;
    'DEFAULT/logfile':   ensure=> absent;
    'DEFAULT/logdir':    ensure=> absent;
-}
-
-if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
- glance_registry_config {
-   'DEFAULT/log_config': value => "/etc/glance/logging.conf";
    'DEFAULT/use_stderr': ensure=> absent;
    'DEFAULT/use_syslog': value => true;
    'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -52,12 +49,15 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
    }
  }
 } else {
-# might be used for stdout logging instead, if configured
  glance_registry_config {
    'DEFAULT/log_config':    ensure=> absent;
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
-   'DEFAULT/use_stderr': value => true;
+   'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/logging_context_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+   'DEFAULT/logging_default_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [-] %(instance)s %(message)s';
  }
  # might be used for stdout logging instead, if configured
  if !defined(File["glance-logging.conf"]) {

--- a/deployment/puppet/glance/templates/logging.conf-nosyslog.erb
+++ b/deployment/puppet/glance/templates/logging.conf-nosyslog.erb
@@ -1,0 +1,24 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = root
+
+[formatters]
+keys = default
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s
+
+
+[logger_root]
+level=NOTSET
+handlers = root
+propagate = 1
+
+
+[handler_root]
+class = StreamHandler
+level=NOTSET
+formatter = default
+args = (sys.stdout,)

--- a/deployment/puppet/glance/templates/logging.conf.erb
+++ b/deployment/puppet/glance/templates/logging.conf.erb
@@ -13,10 +13,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = glance-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = glance-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = glance-%(name)s %(levelname)s %(message)s
+format = glance-%(name)s %(levelname)s: %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/glance/templates/logging.conf.erb
+++ b/deployment/puppet/glance/templates/logging.conf.erb
@@ -13,13 +13,12 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = glance-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = glance-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = glance-%(name)s %(levelname)s: %(module)s %(message)s
+format = glance-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/glance-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>

--- a/deployment/puppet/glance/templates/logging.conf.erb
+++ b/deployment/puppet/glance/templates/logging.conf.erb
@@ -1,24 +1,22 @@
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
 [formatters]
 keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = glance
 
 [formatter_debug]
-format = glance-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = glance-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = glance-%(name)s: %(levelname)s %(message)s
+format = glance-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/glance-all.log
@@ -26,16 +24,41 @@ format = glance-%(name)s: %(levelname)s %(message)s
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
 formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
 args = (sys.stdout,)

--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -19,8 +19,7 @@
 #     Defaults to False.
 #   [use_syslog] Rather or not keystone should log to syslog. Optional.
 #     Defaults to False.
-#   [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option
-#     wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
+#   [syslog_log_facility] Facility for syslog, if used. Optional.
 #   [syslog_log_level] logging level for non verbose and non debug mode. Optional.
 #   [catalog_type] Type of catalog that keystone uses to store endpoints,services. Optional.
 #     Defaults to sql. (Also accepts template)
@@ -88,11 +87,19 @@ class keystone(
     require => Package['keystone'],
   }
 
-  if $use_syslog {
+  keystone_config {
+      'DEFAULT/log_file': ensure=> absent;
+      'DEFAULT/log_dir': ensure=> absent;
+      'DEFAULT/logfile':   ensure=> absent;
+      'DEFAULT/logdir':    ensure=> absent;
+  }
+
+  if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
     keystone_config {
       'DEFAULT/log_config': value => "/etc/keystone/logging.conf";
-      'DEFAULT/log_file': ensure=> absent;
-      'DEFAULT/logdir': ensure=> absent;
+      'DEFAULT/use_stderr': ensure=> absent;
+      'DEFAULT/use_syslog': value => true;
+      'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
     }
     file {"keystone-logging.conf":
       content => template('keystone/logging.conf.erb'),
@@ -106,9 +113,19 @@ class keystone(
     }
   } else  {
     keystone_config {
-     'DEFAULT/log_config': ensure => absent;
-     'DEFAULT/log_file': value => $log_file;
-     'DEFAULT/log_dir': value => $log_dir;
+      # logging for agents grabbing from stderr
+      'DEFAULT/log_config': ensure=> absent;
+      'DEFAULT/use_syslog': ensure=> absent;
+      'DEFAULT/syslog_log_facility': ensure=> absent;
+      'DEFAULT/use_stderr': value => true;
+    }
+    # might be used for stdout logging instead, if configured
+    file {"keystone-logging.conf":
+      content => template('keystone/logging.conf.erb'),
+      path => "/etc/keystone/logging.conf",
+      require => File['/etc/keystone'],
+      # We must notify service for new logging rules
+      notify => Service['keystone'],
     }
   }
 
@@ -169,7 +186,6 @@ class keystone(
     'DEFAULT/compute_port': value => $compute_port;
     'DEFAULT/debug':        value => $debug;
     'DEFAULT/verbose':      value => $verbose;
-    'DEFAULT/use_syslog':   value => $use_syslog;
     'identity/driver': value =>"keystone.identity.backends.sql.Identity";
     'token/driver': value =>"keystone.token.backends.sql.Token";
     'policy/driver': value =>"keystone.policy.backends.rules.Policy";

--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -114,6 +114,7 @@ class keystone(
       'DEFAULT/use_syslog': ensure=> absent;
       'DEFAULT/syslog_log_facility': ensure=> absent;
       'DEFAULT/use_stderr': ensure=> absent;
+      'DEFAULT/log_dir':value=> $log_dir;
     }
     # might be used for stdout logging instead, if configured
     file {"keystone-logging.conf":

--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -87,16 +87,13 @@ class keystone(
     require => Package['keystone'],
   }
 
-  keystone_config {
+  if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
+    keystone_config {
+      'DEFAULT/log_config': value => "/etc/keystone/logging.conf";
       'DEFAULT/log_file': ensure=> absent;
       'DEFAULT/log_dir': ensure=> absent;
       'DEFAULT/logfile':   ensure=> absent;
       'DEFAULT/logdir':    ensure=> absent;
-  }
-
-  if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
-    keystone_config {
-      'DEFAULT/log_config': value => "/etc/keystone/logging.conf";
       'DEFAULT/use_stderr': ensure=> absent;
       'DEFAULT/use_syslog': value => true;
       'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -113,15 +110,14 @@ class keystone(
     }
   } else  {
     keystone_config {
-      # logging for agents grabbing from stderr
       'DEFAULT/log_config': ensure=> absent;
       'DEFAULT/use_syslog': ensure=> absent;
       'DEFAULT/syslog_log_facility': ensure=> absent;
-      'DEFAULT/use_stderr': value => true;
+      'DEFAULT/use_stderr': ensure=> absent;
     }
     # might be used for stdout logging instead, if configured
     file {"keystone-logging.conf":
-      content => template('keystone/logging.conf.erb'),
+      content => template('keystone/logging.conf-nosyslog.erb'),
       path => "/etc/keystone/logging.conf",
       require => File['/etc/keystone'],
       # We must notify service for new logging rules

--- a/deployment/puppet/keystone/templates/logging.conf-nosyslog.erb
+++ b/deployment/puppet/keystone/templates/logging.conf-nosyslog.erb
@@ -1,0 +1,24 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = root
+
+[formatters]
+keys = default
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s
+
+
+[logger_root]
+level=NOTSET
+handlers = root
+propagate = 1
+
+
+[handler_root]
+class = StreamHandler
+level=NOTSET
+formatter = default
+args = (sys.stdout,)

--- a/deployment/puppet/keystone/templates/logging.conf.erb
+++ b/deployment/puppet/keystone/templates/logging.conf.erb
@@ -13,10 +13,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = keystone-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = keystone-%(name)s %(levelname)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/keystone/templates/logging.conf.erb
+++ b/deployment/puppet/keystone/templates/logging.conf.erb
@@ -1,24 +1,22 @@
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
 [formatters]
 keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = keystone
 
 [formatter_debug]
-format = keystone-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = keystone-%(name)s: %(levelname)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/keystone-all.log
@@ -26,16 +24,41 @@ format = keystone-%(name)s: %(levelname)s %(message)s
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
 formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
 args = (sys.stdout,)

--- a/deployment/puppet/keystone/templates/logging.conf.erb
+++ b/deployment/puppet/keystone/templates/logging.conf.erb
@@ -13,13 +13,12 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = keystone-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = keystone-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = keystone-%(name)s %(levelname)s: %(module)s %(message)s
+format = keystone-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/keystone-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>

--- a/deployment/puppet/nova/manifests/init.pp
+++ b/deployment/puppet/nova/manifests/init.pp
@@ -152,9 +152,7 @@ nova_config
  {
  'DEFAULT/log_config': value => "/etc/nova/logging.conf";
  'DEFAULT/log_file': ensure=> absent;
- 'DEFAULT/log_dir': ensure=> absent;
  'DEFAULT/logfile':   ensure=> absent;
- 'DEFAULT/logdir': ensure=> absent;
  'DEFAULT/use_syslog': value =>  true;
  'DEFAULT/use_stderr': ensure=> absent;
  'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -175,6 +173,7 @@ else {
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
    'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/logdir': value=> $logdir;
    'DEFAULT/logging_context_format_string':
     value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
    'DEFAULT/logging_default_format_string':

--- a/deployment/puppet/nova/manifests/init.pp
+++ b/deployment/puppet/nova/manifests/init.pp
@@ -34,8 +34,7 @@
 # $rabbit_nodes = ['node001', 'node002', 'node003']
 # add rabbit nodes hostname
 # [use_syslog] Rather or not service should log to syslog. Optional.
-# [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option 
-#       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
+# [syslog_log_facility] Facility for syslog, if used. Optional.
 # [syslog_log_level] logging level for non verbose and non debug mode. Optional.
 #
 class nova(
@@ -145,21 +144,27 @@ class nova(
     require => Package['nova-common'],
   }
 
+nova_config {
+ 'DEFAULT/log_file': ensure=> absent;
+ 'DEFAULT/log_dir': ensure=> absent;
+ 'DEFAULT/logfile':   ensure=> absent;
+ 'DEFAULT/logdir': ensure=> absent;
+}
+
 #Configure logging in nova.conf
-if $use_syslog
+if $use_syslog and !$debug =~ /(?i)(true|yes)/
  {
 
 nova_config
  {
  'DEFAULT/log_config': value => "/etc/nova/logging.conf";
- 'DEFAULT/log_file': ensure=> absent;
- 'DEFAULT/logdir': ensure=> absent;
- 'DEFAULT/use_syslog': value =>  "True";
+ 'DEFAULT/use_syslog': value =>  true;
+ 'DEFAULT/use_stderr': ensure=> absent;
  'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
- 'DEFAULT/logging_context_format_string':
-  value => '%(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
- 'DEFAULT/logging_default_format_string':
- value =>'%(levelname)s %(name)s [-] %(instance)s %(message)s';
+# 'DEFAULT/logging_context_format_string':
+#  value => '%(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+# 'DEFAULT/logging_default_format_string':
+# value =>'%(levelname)s %(name)s [-] %(instance)s %(message)s';
 }
 
 file {"nova-logging.conf":
@@ -169,6 +174,22 @@ file {"nova-logging.conf":
 }
 file { "nova-all.log":
   path => "/var/log/nova-all.log",
+}
+}
+else {
+  nova_config {
+   # logging for agents grabbing from stderr
+   'DEFAULT/log_config': ensure=> absent;
+   'DEFAULT/use_syslog': ensure=> absent;
+   'DEFAULT/syslog_log_facility': ensure=> absent;
+   'DEFAULT/use_stderr': value => true;
+  }
+  # might be used for stdout logging instead, if configured
+  file {"nova-logging.conf":
+    content => template('nova/logging.conf-nosyslog.erb'),
+    path => "/etc/nova/logging.conf",
+    require => File[$logdir],
+  }
 }
 
 # We must notify services to apply new logging rules
@@ -188,14 +209,6 @@ File['nova-logging.conf'] ~> Service <| title == "$nova::params::vncproxy_servic
 File['nova-logging.conf'] ~> Service <| title == "$nova::params::volume_service_name" |>
 File['nova-logging.conf'] ~> Service <| title == "$nova::params::meta_api_service_name" |>
 
-}
-else {
-  nova_config {
-   'DEFAULT/log_config': ensure=>absent;
-   'DEFAULT/use_syslog': value =>"False";
-   'DEFAULT/logdir':     value => $logdir;
-  }
-}
   file { $logdir:
     ensure  => directory,
     mode    => '0751',

--- a/deployment/puppet/nova/manifests/init.pp
+++ b/deployment/puppet/nova/manifests/init.pp
@@ -144,13 +144,6 @@ class nova(
     require => Package['nova-common'],
   }
 
-nova_config {
- 'DEFAULT/log_file': ensure=> absent;
- 'DEFAULT/log_dir': ensure=> absent;
- 'DEFAULT/logfile':   ensure=> absent;
- 'DEFAULT/logdir': ensure=> absent;
-}
-
 #Configure logging in nova.conf
 if $use_syslog and !$debug =~ /(?i)(true|yes)/
  {
@@ -158,13 +151,13 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/
 nova_config
  {
  'DEFAULT/log_config': value => "/etc/nova/logging.conf";
+ 'DEFAULT/log_file': ensure=> absent;
+ 'DEFAULT/log_dir': ensure=> absent;
+ 'DEFAULT/logfile':   ensure=> absent;
+ 'DEFAULT/logdir': ensure=> absent;
  'DEFAULT/use_syslog': value =>  true;
  'DEFAULT/use_stderr': ensure=> absent;
  'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
-# 'DEFAULT/logging_context_format_string':
-#  value => '%(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
-# 'DEFAULT/logging_default_format_string':
-# value =>'%(levelname)s %(name)s [-] %(instance)s %(message)s';
 }
 
 file {"nova-logging.conf":
@@ -178,11 +171,14 @@ file { "nova-all.log":
 }
 else {
   nova_config {
-   # logging for agents grabbing from stderr
    'DEFAULT/log_config': ensure=> absent;
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
-   'DEFAULT/use_stderr': value => true;
+   'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/logging_context_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+   'DEFAULT/logging_default_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [-] %(instance)s %(message)s';
   }
   # might be used for stdout logging instead, if configured
   file {"nova-logging.conf":

--- a/deployment/puppet/nova/templates/logging.conf-nosyslog.erb
+++ b/deployment/puppet/nova/templates/logging.conf-nosyslog.erb
@@ -1,0 +1,24 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = root
+
+[formatters]
+keys = default
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s
+
+
+[logger_root]
+level=NOTSET
+handlers = root
+propagate = 1
+
+
+[handler_root]
+class = StreamHandler
+level=NOTSET
+formatter = default
+args = (sys.stdout,)

--- a/deployment/puppet/nova/templates/logging.conf.erb
+++ b/deployment/puppet/nova/templates/logging.conf.erb
@@ -13,10 +13,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = nova-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = nova-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = nova-%(name)s %(levelname)s %(message)s
+format = nova-%(name)s %(levelname)s: %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/nova/templates/logging.conf.erb
+++ b/deployment/puppet/nova/templates/logging.conf.erb
@@ -13,13 +13,12 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = nova-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = nova-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = nova-%(name)s %(levelname)s: %(module)s %(message)s
+format = nova-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/nova-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>

--- a/deployment/puppet/nova/templates/logging.conf.erb
+++ b/deployment/puppet/nova/templates/logging.conf.erb
@@ -1,24 +1,22 @@
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
 [formatters]
 keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = nova
 
 [formatter_debug]
-format = nova-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = nova-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = nova-%(name)s: %(levelname)s %(message)s
+format = nova-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/nova-all.log
@@ -26,16 +24,41 @@ format = nova-%(name)s: %(levelname)s %(message)s
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
 formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
 args = (sys.stdout,)

--- a/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
@@ -402,7 +402,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
@@ -375,6 +375,15 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
 $use_syslog = true
@@ -465,15 +474,6 @@ $openstack_version = {
 $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = false
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
@@ -402,7 +402,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => true,
+    show_timezone => false,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
@@ -427,7 +427,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => true,
+    show_timezone => false,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
@@ -400,6 +400,15 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
 $use_syslog = true
@@ -490,15 +499,6 @@ $openstack_version = {
 $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = true
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
@@ -427,7 +427,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
@@ -449,7 +449,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
@@ -422,6 +422,15 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
 $use_syslog = true
@@ -512,15 +521,6 @@ $openstack_version = {
 $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = false
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
@@ -449,7 +449,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => true,
+    show_timezone => false,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
@@ -392,7 +392,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
@@ -392,7 +392,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => true,
+    show_timezone => false,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
@@ -365,6 +365,14 @@ if $node[0]['role'] == 'primary-controller' {
   $primary_controller = false
 }
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
 
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
@@ -456,15 +464,6 @@ $openstack_version = {
 $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = true
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_simple.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_simple.pp
@@ -308,6 +308,15 @@ $swift_loopback = false
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case,
 # and configured to start at the very beginning of puppet agent run.
@@ -399,15 +408,6 @@ $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
 $use_upstream_mysql = true
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = true
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_simple.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_simple.pp
@@ -336,7 +336,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_simple.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_simple.pp
@@ -336,7 +336,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => true,
+    show_timezone => false,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_single.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_single.pp
@@ -277,6 +277,15 @@ $swift_loopback = false
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case,
 # and configured to start at the very beginning of puppet agent run.
@@ -368,15 +377,6 @@ $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
 $use_upstream_mysql = true
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = false
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_single.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_single.pp
@@ -305,7 +305,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_single.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_single.pp
@@ -305,7 +305,7 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => true,
+    show_timezone => false,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/templates/20-fuel.conf.erb
+++ b/deployment/puppet/openstack/templates/20-fuel.conf.erb
@@ -1,6 +1,8 @@
 "/var/log/*-all.log" "/var/log/remote/*/*log"
 "/var/log/kern.log" "/var/log/debug" "/var/log/syslog"
 "/var/log/dashboard.log" "/var/log/ha.log" "/var/log/quantum/*.log"
+"/var/log/nova/*.log" "/var/log/keystone/*.log" "/var/log/glance/*.log"
+"/var/log/cinder/*.log"
 # This file is used for hourly log rotations, use (min)size options here
 {
   sharedscripts

--- a/deployment/puppet/quantum/files/ocf/quantum-agent-l3
+++ b/deployment/puppet/quantum/files/ocf/quantum-agent-l3
@@ -318,24 +318,25 @@ quantum_l3_agent_start() {
 
     clean_up
 
-    if ocf_is_true ${OCF_RESKEY_syslog} ; then
+# FIXME stderr should not be used unless quantum+agents init & OCF would reditect to stderr
+#    if ocf_is_true ${OCF_RESKEY_syslog} ; then
 # Disable logger because we use imfile for log files grabbing to rsyslog
 #      L3_SYSLOG=" | logger -t quantum-quantum.agent.l3 "
-        L3_SYSLOG=""
-        if ocf_is_true ${OCF_RESKEY_debug} ; then
-            L3_LOG=" | tee -ia /var/log/quantum/l3.log "
-        else
-            L3_LOG=" "
-        fi
-    else
-        L3_SYSLOG=""
-        if ocf_is_true ${OCF_RESKEY_debug} ; then
-            L3_LOG=" >> /var/log/quantum/l3.log "
-        else
-            L3_LOG=" >> /dev/null "
-        fi
-    fi
-
+#        if ocf_is_true ${OCF_RESKEY_debug} ; then
+#            L3_LOG=" | tee -ia /var/log/quantum/l3.log "
+#        else
+#            L3_LOG=" "
+#        fi
+#    else
+#        L3_SYSLOG=""
+#        if ocf_is_true ${OCF_RESKEY_debug} ; then
+#            L3_LOG=" >> /var/log/quantum/l3.log "
+#        else
+#            L3_LOG=" >> /dev/null "
+#        fi
+#    fi
+    L3_SYSLOG=""
+    L3_LOG=" > /dev/null "
     # run the actual quantum-l3-agent daemon. Don't use ocf_run as we're sending the tool's output
     # straight to /dev/null anyway and using ocf_run would break stdout-redirection here.
 

--- a/deployment/puppet/quantum/files/ocf/quantum-agent-l3
+++ b/deployment/puppet/quantum/files/ocf/quantum-agent-l3
@@ -319,7 +319,9 @@ quantum_l3_agent_start() {
     clean_up
 
     if ocf_is_true ${OCF_RESKEY_syslog} ; then
-        L3_SYSLOG=" | logger -t quantum-quantum.agent.l3 "
+# Disable logger because we use imfile for log files grabbing to rsyslog
+#      L3_SYSLOG=" | logger -t quantum-quantum.agent.l3 "
+        L3_SYSLOG=""
         if ocf_is_true ${OCF_RESKEY_debug} ; then
             L3_LOG=" | tee -ia /var/log/quantum/l3.log "
         else

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -139,14 +139,27 @@ class quantum (
   }
   # logging for agents grabbing from stderr. It's workarround for bug in quantum-logging
   # server givs this parameters from command line
+  # FIXME change init.d scripts for q&agents for non HA mode, change daemon launch commands (CENTOS/RHEL):
+  # FIXME quantum-server:
+  # FIXME	daemon --user quantum --pidfile $pidfile "$exec --config-file $config --config-file /etc/$prog/plugin.ini &>>/var/log/quantum/server.log & echo \$!
+  # FIXME quantum-ovs-cleanup:
+  # FIXME	daemon --user quantum $exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log
+  # quantum-ovs/metadata/l3/dhcp/-agents:
+  # FIXME	daemon --user quantum --pidfile $pidfile "$exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log & echo \$! > $pidfile"
+
   quantum_config {
-      'DEFAULT/log_config': ensure=> absent;
       'DEFAULT/log_file':   ensure=> absent;
       'DEFAULT/log_dir':    ensure=> absent;
-      'DEFAULT/use_syslog': ensure=> absent;
-      'DEFAULT/use_stderr': value => true;
+      'DEFAULT/logfile':    ensure=> absent;
+      'DEFAULT/logdir':     ensure=> absent;
   }
   if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
+    quantum_config {
+        'DEFAULT/log_config':   value => "/etc/quantum/logging.conf";
+        'DEFAULT/use_stderr': ensure=> absent;
+        'DEFAULT/use_syslog': value=> true;
+        'DEFAULT/syslog_log_facility': value=> $syslog_log_facility;
+    }
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf.erb'),
       path  => "/etc/quantum/logging.conf",
@@ -160,9 +173,9 @@ class quantum (
   } else {
     quantum_config {
     # logging for agents grabbing from stderr. It's workarround for bug in quantum-logging
-      'DEFAULT/log_file':   ensure=> absent;
-      'DEFAULT/log_dir':    ensure=> absent;
       'DEFAULT/use_syslog': ensure=> absent;
+      'DEFAULT/syslog_log_facility': ensure=> absent;
+      'DEFAULT/log_config': ensure=> absent;
       'DEFAULT/use_stderr': value => true;
     }
     file { "quantum-logging.conf":

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -1,7 +1,6 @@
 #
 # [use_syslog] Rather or not service should log to syslog. Optional.
-# [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option
-#       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
+# [syslog_log_facility] Facility for syslog, if used. Optional.
 # [syslog_log_level] logging level for non verbose and non debug mode. Optional.
 #
 class quantum (
@@ -147,7 +146,7 @@ class quantum (
       'DEFAULT/use_syslog': ensure=> absent;
       'DEFAULT/use_stderr': value => true;
   }
-  if $use_syslog {
+  if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf.erb'),
       path  => "/etc/quantum/logging.conf",
@@ -158,23 +157,27 @@ class quantum (
     file { "quantum-all.log":
       path => "/var/log/quantum-all.log",
     }
-
-    # We must setup logging before start services under pacemaker
-    File['quantum-logging.conf'] -> Service<| title == 'quantum-server' |>
-    File['quantum-logging.conf'] -> Anchor<| title == 'quantum-ovs-agent' |>
-    File['quantum-logging.conf'] -> Anchor<| title == 'quantum-l3' |>
-    File['quantum-logging.conf'] -> Anchor<| title == 'quantum-dhcp-agent' |>
-
   } else {
+    quantum_config {
+    # logging for agents grabbing from stderr. It's workarround for bug in quantum-logging
+      'DEFAULT/log_file':   ensure=> absent;
+      'DEFAULT/log_dir':    ensure=> absent;
+      'DEFAULT/use_syslog': ensure=> absent;
+      'DEFAULT/use_stderr': value => true;
+    }
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf-nosyslog.erb'),
       path  => "/etc/quantum/logging.conf",
       owner => "root",
-      group => "root",
-      mode  => 644,
+      group => "quantum",
+      mode  => 640,
     }
   }
-
+  # We must setup logging before start services under pacemaker
+  File['quantum-logging.conf'] -> Service<| title == 'quantum-server' |>
+  File['quantum-logging.conf'] -> Anchor<| title == 'quantum-ovs-agent' |>
+  File['quantum-logging.conf'] -> Anchor<| title == 'quantum-l3' |>
+  File['quantum-logging.conf'] -> Anchor<| title == 'quantum-dhcp-agent' |>
   File <| title=='/etc/quantum' |> -> File <| title=='quantum-logging.conf' |>
 
   if defined(Anchor['quantum-server-config-done']) {

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -33,6 +33,7 @@ class quantum (
   $auth_tenant      = 'services',
   $auth_user        = 'quantum',
   $log_file               = '/var/log/quantum/server.log',
+  $log_dir          = '/var/log/quantum',
   $use_syslog = false,
   $syslog_log_facility    = 'LOCAL4',
   $syslog_log_level = 'WARNING',
@@ -149,12 +150,12 @@ class quantum (
 
   quantum_config {
       'DEFAULT/log_file':   ensure=> absent;
-      'DEFAULT/log_dir':    ensure=> absent;
       'DEFAULT/logfile':    ensure=> absent;
-      'DEFAULT/logdir':     ensure=> absent;
   }
   if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
     quantum_config {
+        'DEFAULT/log_dir':    ensure=> absent;
+        'DEFAULT/logdir':     ensure=> absent;
         'DEFAULT/log_config':   value => "/etc/quantum/logging.conf";
         'DEFAULT/use_stderr': ensure=> absent;
         'DEFAULT/use_syslog': value=> true;
@@ -179,6 +180,7 @@ class quantum (
       # FIXME stderr should not be used unless quantum+agents init & OCF scripts would be fixed to redirect its output to stderr!
       #'DEFAULT/use_stderr': value => true;
       'DEFAULT/use_stderr': ensure=> absent;
+      'DEFAULT/log_dir': value => $log_dir;
     }
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf-nosyslog.erb'),

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -176,7 +176,9 @@ class quantum (
       'DEFAULT/use_syslog': ensure=> absent;
       'DEFAULT/syslog_log_facility': ensure=> absent;
       'DEFAULT/log_config': ensure=> absent;
-      'DEFAULT/use_stderr': value => true;
+      # FIXME stderr should not be used unless quantum+agents init & OCF scripts would be fixed to redirect its output to stderr!
+      #'DEFAULT/use_stderr': value => true;
+      'DEFAULT/use_stderr': ensure=> absent;
     }
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf-nosyslog.erb'),

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -140,13 +140,13 @@ class quantum (
   }
   # logging for agents grabbing from stderr. It's workarround for bug in quantum-logging
   # server givs this parameters from command line
-  # FIXME change init.d scripts for q&agents for non HA mode, change daemon launch commands (CENTOS/RHEL):
-  # FIXME quantum-server:
-  # FIXME	daemon --user quantum --pidfile $pidfile "$exec --config-file $config --config-file /etc/$prog/plugin.ini &>>/var/log/quantum/server.log & echo \$!
-  # FIXME quantum-ovs-cleanup:
-  # FIXME	daemon --user quantum $exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log
+  # FIXME change init.d scripts for q&agents, fix daemon launch commands (CENTOS/RHEL):
+  # quantum-server:
+  #	daemon --user quantum --pidfile $pidfile "$exec --config-file $config --config-file /etc/$prog/plugin.ini &>>/var/log/quantum/server.log & echo \$!
+  # quantum-ovs-cleanup:
+  # 	daemon --user quantum $exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log
   # quantum-ovs/metadata/l3/dhcp/-agents:
-  # FIXME	daemon --user quantum --pidfile $pidfile "$exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log & echo \$! > $pidfile"
+  # 	daemon --user quantum --pidfile $pidfile "$exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log & echo \$! > $pidfile"
 
   quantum_config {
       'DEFAULT/log_file':   ensure=> absent;
@@ -203,11 +203,11 @@ class quantum (
     $endpoint_quantum_main_configuration = 'quantum-init-done'
   }
 
-  # FIXME remove explicit --log-config from init scripts cuz it breaks logging!
+  # FIXME Workaround for FUEL-842: remove explicit --log-config from init scripts cuz it breaks logging!
+  # FIXME this hack should be deleted after FUEL-842 have resolved
   exec {'init-dirty-hack':
     command => "sed -i 's/\-\-log\-config=\$loggingconf//g' /etc/init.d/quantum-*",
     path    => ["/sbin", "/bin", "/usr/sbin", "/usr/bin"],
-    refreshonly => true,
   }
 
   Anchor['quantum-init'] ->

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -203,8 +203,16 @@ class quantum (
     $endpoint_quantum_main_configuration = 'quantum-init-done'
   }
 
+  # FIXME remove explicit --log-config from init scripts cuz it breaks logging!
+  exec {'init-dirty-hack':
+    command => "sed -i 's/\-\-log\-config=\$loggingconf//g' /etc/init.d/quantum-*",
+    path    => ["/sbin", "/bin", "/usr/sbin", "/usr/bin"],
+    refreshonly => true,
+  }
+
   Anchor['quantum-init'] ->
     Package['quantum'] ->
+     Exec['init-dirty-hack'] ->
       File['/var/cache/quantum'] ->
         Quantum_config<||> ->
           Quantum_api_config<||> ->

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -1,11 +1,20 @@
+<% if @debug then -%>
+[loggers]
+keys = root, l3agent, ovsagent, dhcpagent, metadata
+
+[handlers]
+keys = production,devel,stderr, l3agent, ovsagent, dhcpagent, metadata
+
+<% else -%>
 [loggers]
 keys = root
 
 [handlers]
 keys = production,devel,stderr
 
+<% end -%>
 [formatters]
-keys = normal,debug
+keys = normal,debug,default
 
 [logger_root]
 level = NOTSET
@@ -13,13 +22,15 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = quantum-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = quantum-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = quantum-%(name)s %(levelname)s: %(module)s %(message)s
+format = quantum-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/quantum-all.log
+[formatter_default]
+format=%(asctime)s %(levelname)s %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s
+
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>
@@ -62,3 +73,48 @@ level = <%= @syslog_log_level %>
 formatter = normal
 <% end -%>
 args = (sys.stdout,)
+
+<% if @debug then -%>
+[logger_l3agent]
+handlers = l3agent
+level=NOTSET
+qualname = quantum.agent.l3_agent
+
+[handler_l3agent]
+class = logging.FileHandler
+args = ('/var/log/quantum/l3.log',)
+formatter = default
+
+
+[logger_dhcpagent]
+handlers = dhcpagent
+level=NOTSET
+qualname = quantum.agent.dhcp_agent
+
+[handler_dhcpagent]
+class = logging.FileHandler
+args = ('/var/log/quantum/dhcp.log',)
+formatter = default
+
+
+[logger_ovsagent]
+handlers = ovsagent
+level=NOTSET
+qualname = quantum.plugins.openvswitch.agent.ovs_quantum_agent
+
+[handler_ovsagent]
+class = logging.FileHandler
+args = ('/var/log/quantum/ovs.log',)
+formatter = default
+
+
+[logger_metadata]
+handlers = metadata
+level=NOTSET
+qualname = quantum.agent.metadata
+
+[handler_metadata]
+class = logging.FileHandler
+args = ('/var/log/quantum/metadata.log',)
+formatter = default
+<% end -%>

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -1,37 +1,22 @@
-<% if @debug then -%>
-[loggers]
-keys = root, l3agent, ovsagent, dhcpagent, metadata
-
-[handlers]
-keys = production,devel, l3agent, ovsagent, dhcpagent, metadata
-
-<% else -%>
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
-<% end -%>
+[formatters]
+keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = quantum
-
-[formatters]
-keys = normal,debug,default
 
 [formatter_debug]
-format = quantum-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = quantum-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = quantum-%(name)s: %(levelname)s %(message)s
-
-[formatter_default]
-format=%(asctime)s %(levelname)s %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s
+format = quantum-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/quantum-all.log
@@ -39,61 +24,41 @@ format=%(asctime)s %(levelname)s %(module)s %(name)s:%(lineno)d %(funcName)s  %(
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
-formatter = debug
-args = (sys.stdout,)
-
 <% if @debug then -%>
-[logger_l3agent]
-handlers = l3agent
-level=NOTSET
-qualname = quantum.agent.l3_agent
-
-[handler_l3agent]
-class = logging.FileHandler
-args = ('/var/log/quantum/l3.log',)
-formatter = default
-
-
-[logger_dhcpagent]
-handlers = dhcpagent
-level=NOTSET
-qualname = quantum.agent.dhcp_agent
-
-[handler_dhcpagent]
-class = logging.FileHandler
-args = ('/var/log/quantum/dhcp.log',)
-formatter = default
-
-
-[logger_ovsagent]
-handlers = ovsagent
-level=NOTSET
-qualname = quantum.plugins.openvswitch.agent.ovs_quantum_agent
-
-[handler_ovsagent]
-class = logging.FileHandler
-args = ('/var/log/quantum/ovs.log',)
-formatter = default
-
-
-[logger_metadata]
-handlers = metadata
-level=NOTSET
-qualname = quantum.agent.metadata
-
-[handler_metadata]
-class = logging.FileHandler
-args = ('/var/log/quantum/metadata.log',)
-formatter = default
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
+args = (sys.stdout,)

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -22,13 +22,13 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = quantum-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = quantum-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = quantum-%(name)s %(levelname)s %(message)s
+format = quantum-%(name)s %(levelname)s: %(message)s
 
 [formatter_default]
-format=%(asctime)s %(levelname)s %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s
+format=%(asctime)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/rsyslog/manifests/client.pp
+++ b/deployment/puppet/rsyslog/manifests/client.pp
@@ -195,28 +195,28 @@ if $::debug =~ /(?i)(true|yes)/ {
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-ovs-agent_debug" :
-    file_name     => "/var/log/quantum/ovs-agent.log",
+    file_name     => "/var/log/quantum/ovs.log",
     file_tag      => "quantum-ovs-agent",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-l3-agent_debug" :
-    file_name     => "/var/log/quantum/l3-agent.log",
+    file_name     => "/var/log/quantum/l3.log",
     file_tag      => "quantum-l3-agent",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-dhcp-agent_debug" :
-    file_name     => "/var/log/quantum/dhcp-agent.log",
+    file_name     => "/var/log/quantum/dhcp.log",
     file_tag      => "quantum-dhcp-agent",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-metadata-agent_debug" :
-    file_name     => "/var/log/quantum/metadata-agent.log",
+    file_name     => "/var/log/quantum/metadata.log",
     file_tag      => "quantum-metadata-agent",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",

--- a/deployment/puppet/rsyslog/manifests/client.pp
+++ b/deployment/puppet/rsyslog/manifests/client.pp
@@ -194,34 +194,72 @@ if $::debug =~ /(?i)(true|yes)/ {
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
+::rsyslog::imfile { "50-quantum-rescheduling_debug" :
+   file_name     => "/var/log/quantum/rescheduling.log",
+   file_tag      => "quantum-rescheduling",
+   file_facility => $::syslog_log_facility_quantum,
+   file_severity => "DEBUG",
+   notify  => Class["rsyslog::service"],
+}
 ::rsyslog::imfile { "50-quantum-ovs-agent_debug" :
-    file_name     => "/var/log/quantum/ovs.log",
-    file_tag      => "quantum-ovs-agent",
+    file_name     => "/var/log/quantum/openvswitch-agent.log",
+    file_tag      => "quantum-agent-ovs",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-l3-agent_debug" :
-    file_name     => "/var/log/quantum/l3.log",
-    file_tag      => "quantum-l3-agent",
+    file_name     => "/var/log/quantum/l3-agent.log",
+    file_tag      => "quantum-agent-l3",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-dhcp-agent_debug" :
-    file_name     => "/var/log/quantum/dhcp.log",
-    file_tag      => "quantum-dhcp-agent",
+    file_name     => "/var/log/quantum/dhcp-agent.log",
+    file_tag      => "quantum-agent-dhcp",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-metadata-agent_debug" :
-    file_name     => "/var/log/quantum/metadata.log",
-    file_tag      => "quantum-metadata-agent",
+    file_name     => "/var/log/quantum/metadata-agent.log",
+    file_tag      => "quantum-agent-metadata",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
+# FIXME Workaround for FUEL-843 (HA any)
+# FIXME remove after FUEL-843 have reolved
+::rsyslog::imfile { "50-ha-quantum-ovs-agent_debug" :
+    file_name     => "/var/log/quantum/quantum-openvswitch-agent.log",
+    file_tag      => "quantum-agent-ovs",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-ha-quantum-l3-agent_debug" :
+    file_name     => "/var/log/quantum/quantum-l3-agent.log",
+    file_tag      => "quantum-agent-l3",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-ha-quantum-dhcp-agent_debug" :
+    file_name     => "/var/log/quantum/quantum-dhcp-agent.log",
+    file_tag      => "quantum-agent-dhcp",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-ha-quantum-metadata-agent_debug" :
+    file_name     => "/var/log/quantum/quantum-metadata-agent.log",
+    file_tag      => "quantum-agent-metadata",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+# END fixme
 } else { #non debug case
 # standard logging configs for syslog client
   file { "${rsyslog::params::rsyslog_d}10-nova.conf":

--- a/deployment/puppet/rsyslog/manifests/client.pp
+++ b/deployment/puppet/rsyslog/manifests/client.pp
@@ -79,16 +79,151 @@ if $virtual { include rsyslog::checksum_udp514 }
     notify  => Class["rsyslog::service"],
   }
 
-  file { "${rsyslog::params::rsyslog_d}02-ha.conf":
-    ensure => present,
-    content => template("${module_name}/02-ha.conf.erb"),
-  }
-
-  file { "${rsyslog::params::rsyslog_d}03-dashboard.conf":
-    ensure => present,
-    content => template("${module_name}/03-dashboard.conf.erb"),
-  }
-
+# openstack syslog compatible mode, would work only for debug case.
+# because of its poor syslog debug messages quality, use local logs convertion
+if $::debug =~ /(?i)(true|yes)/ {
+::rsyslog::imfile { "10-nova-api_debug" :
+    file_name     => "/var/log/nova/api.log",
+    file_tag      => "nova-api",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-cert_debug" :
+    file_name     => "/var/log/nova/cert.log",
+    file_tag      => "nova-cert",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-consoleauth_debug" :
+    file_name     => "/var/log/nova/consoleauth.log",
+    file_tag      => "nova-consoleauth",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-scheduler_debug" :
+    file_name     => "/var/log/nova/scheduler.log",
+    file_tag      => "nova-scheduler",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-network_debug" :
+    file_name     => "/var/log/nova/network.log",
+    file_tag      => "nova-network",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-compute_debug" :
+    file_name     => "/var/log/nova/compute.log",
+    file_tag      => "nova-compute",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-conductor_debug" :
+    file_name     => "/var/log/nova/conductor.log",
+    file_tag      => "nova-conductor",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-objectstore_debug" :
+    file_name     => "/var/log/nova/objectstore.log",
+    file_tag      => "nova-objectstore",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "20-keystone_debug" :
+    file_name     => "/var/log/keystone/keystone.log",
+    file_tag      => "keystone",
+    file_facility => $::syslog_log_facility_keystone,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "30-cinder-api_debug" :
+    file_name     => "/var/log/cinder/api.log",
+    file_tag      => "cinder-api",
+    file_facility => $::syslog_log_facility_cinder,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "30-cinder-volume_debug" :
+    file_name     => "/var/log/cinder/volume.log",
+    file_tag      => "cinder-volume",
+    file_facility => $::syslog_log_facility_cinder,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "30-cinder-scheduler_debug" :
+    file_name     => "/var/log/cinder/scheduler.log",
+    file_tag      => "cinder-scheduler",
+    file_facility => $::syslog_log_facility_cinder,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "40-glance-api_debug" :
+    file_name     => "/var/log/glance/api.log",
+    file_tag      => "glance-api",
+    file_facility => $::syslog_log_facility_glance,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "40-glance-registry_debug" :
+    file_name     => "/var/log/glance/registry.log",
+    file_tag      => "glance-registry",
+    file_facility => $::syslog_log_facility_glance,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-server_debug" :
+    file_name     => "/var/log/quantum/server.log",
+    file_tag      => "quantum-server",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-ovs-cleanup_debug" :
+    file_name     => "/var/log/quantum/ovs-cleanup.log",
+    file_tag      => "quantum-ovs-cleanup",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-ovs-agent_debug" :
+    file_name     => "/var/log/quantum/ovs-agent.log",
+    file_tag      => "quantum-ovs-agent",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-l3-agent_debug" :
+    file_name     => "/var/log/quantum/l3-agent.log",
+    file_tag      => "quantum-l3-agent",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-dhcp-agent_debug" :
+    file_name     => "/var/log/quantum/dhcp-agent.log",
+    file_tag      => "quantum-dhcp-agent",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-metadata-agent_debug" :
+    file_name     => "/var/log/quantum/metadata-agent.log",
+    file_tag      => "quantum-metadata-agent",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+} else { #non debug case
+# standard logging configs for syslog client
   file { "${rsyslog::params::rsyslog_d}10-nova.conf":
     ensure => present,
     content => template("${module_name}/10-nova.conf.erb"),
@@ -113,6 +248,18 @@ if $virtual { include rsyslog::checksum_udp514 }
     ensure => present,
     content => template("${module_name}/50-quantum.conf.erb"),
   }
+} #end if
+
+  file { "${rsyslog::params::rsyslog_d}02-ha.conf":
+    ensure => present,
+    content => template("${module_name}/02-ha.conf.erb"),
+  }
+
+  file { "${rsyslog::params::rsyslog_d}03-dashboard.conf":
+    ensure => present,
+    content => template("${module_name}/03-dashboard.conf.erb"),
+  }
+
 
   file { "${rsyslog::params::rsyslog_d}60-puppet-agent.conf":
     content => template("${module_name}/60-puppet-agent.conf.erb"),

--- a/iso/bootstrap_admin_node.sh
+++ b/iso/bootstrap_admin_node.sh
@@ -38,7 +38,7 @@ puppet apply -e "
       limitsize      => '100M',
       port           => '514',
       proto          => 'udp',
-      show_timezone  => false,
+      show_timezone  => true,
      #virtual        => false,
     }"
 puppet apply -e "

--- a/iso/bootstrap_admin_node.sh
+++ b/iso/bootstrap_admin_node.sh
@@ -32,13 +32,13 @@ puppet apply -e "
       log_remote     => false,
       log_local      => true,
       log_auth_local => true,
-      rotation       => 'daily',
-      keep           => '7',
+      rotation       => 'weekly',
+      keep           => '4',
       # should be > 30M
       limitsize      => '100M',
       port           => '514',
       proto          => 'udp',
-      show_timezone  => true,
+      show_timezone  => false,
      #virtual        => false,
     }"
 puppet apply -e "


### PR DESCRIPTION
Implements option 2 for 835 suggested solutions
WA for FUEL-842, FUEL-843
- StdErr _must not_ be used unless all quantum+agents init & ocf scripts would redirect its stderr 
  to logfiles (&>>/var/log/foo/bar.log)
- Thus, undo powerfull debug via stderr - https://github.com/Mirantis/fuel/pull/373
- Remove use_stderr, use logdir options for stdout instead
- Dirty hack for quantum init script to remove all its --log-config from daemon, cuz it breaks logging
- Use rsyslog::imfile monitoring features for local openstack logfiles for syslog + debug case
- Fix imfile templates for quantum debug to use normalized syslogtags
- Put verbose/debug section on top of site.pp to fix top scope definitions issues for logging class
- Traditional timestamps date-rfc3164 (Dec 5 02:21:13) as default
- Weekly rotate & keep rotated logs for 4 weeks at master node as default
