### PR TITLE
Remove double declaration

### DIFF
--- a/deployment/puppet/puppetmaster/manifests/master.pp
+++ b/deployment/puppet/puppetmaster/manifests/master.pp
@@ -23,14 +23,15 @@ class puppetmaster::master (
     notify => Service["puppetmaster"],
   }
 
-  if $puppet_master_log == "syslog" {
-    file { "/etc/rsyslog.d/40-puppet-master.conf":
-      content => "if \$programname == 'puppet-master' then /var/log/puppet/master.log",
-      owner => "root",
-      group => "root",
-      mode => 0644,
-    }->Service["rsyslog"]->Service["puppetmaster"]
-  }
+  # Already declared @ rsyslog::server class
+  #  if $puppet_master_log == "syslog" {
+  #  file { "/etc/rsyslog.d/40-puppet-master.conf":
+  #    content => "if \$programname == 'puppet-master' then /var/log/puppet/master.log",
+  #    owner => "root",
+  #    group => "root",
+  #    mode => 0644,
+  #  }->Service["rsyslog"]->Service["puppetmaster"]
+  #}
 
   file { "/etc/puppet/puppet.conf":
     content => template("puppetmaster/puppet.conf.erb"),
@@ -49,7 +50,7 @@ class puppetmaster::master (
     require => Package["puppet-server"],
     notify => Service["puppetmaster"],
   }
- 
+
  package {"puppetdb-terminus": ensure => present }
 
   service { "puppetmaster":


### PR DESCRIPTION
would ignore puppet_master_log setting and create rsyslog rule for puppet-master log
if this option should not be ignored, do not merge it (rsyslog::server declaration should be removed then)

Signed-off-by: Bogdan Dobrelya bogdando@mail.ru
