### PR TITLE
Fix corosync hostname FDQN bug. Fix packages for MySQL

### DIFF
--- a/deployment/puppet/corosync/manifests/cleanup.pp
+++ b/deployment/puppet/corosync/manifests/cleanup.pp
@@ -18,9 +18,10 @@ define corosync::cleanup () {
   Cs_resource <| name == $name |> ~> Exec["crm resource cleanup $name"]
 
   ##FIXME: we need to create a better way to workaround crm commit <-> cleanup race condition than a simple sleep 
-
+  #Workaround for hostname bugs with FQDN vs short hostname
   exec { "crm resource cleanup $name":
-    command     => "bash -c \"(sleep 5 && crm_resource --resource $name  --cleanup --node `hostname -s`) || :\"",
+    command     => "bash -c \"(sleep 5 && crm_resource --resource $name  --cleanup --node \$HOSTNAME) || :\"",
+    #command     => "bash -c \"(sleep 5 && crm_resource --resource $name  --cleanup --node $::hostname) || :\"",
     path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
     returns     => [0,""],
     refreshonly => true,

--- a/deployment/puppet/corosync/manifests/cleanup.pp
+++ b/deployment/puppet/corosync/manifests/cleanup.pp
@@ -20,8 +20,7 @@ define corosync::cleanup () {
   ##FIXME: we need to create a better way to workaround crm commit <-> cleanup race condition than a simple sleep 
   #Workaround for hostname bugs with FQDN vs short hostname
   exec { "crm resource cleanup $name":
-    command     => "bash -c \"(sleep 5 && crm_resource --resource $name  --cleanup --node \$HOSTNAME) || :\"",
-    #command     => "bash -c \"(sleep 5 && crm_resource --resource $name  --cleanup --node $::hostname) || :\"",
+    command     => "bash -c \"(sleep 5 && crm_resource --resource $name  --cleanup --node `uname -n`) || :\"",
     path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
     returns     => [0,""],
     refreshonly => true,

--- a/deployment/puppet/mysql/manifests/params.pp
+++ b/deployment/puppet/mysql/manifests/params.pp
@@ -31,12 +31,24 @@ class mysql::params {
       $basedir               = '/usr'
       $datadir               = '/var/lib/mysql'
       $service_name          = 'mysql'
-      $client_package_name   = 'MySQL-client'
-      $client_version        = '5.5.28-6'
-      $server_package_name   = 'MySQL-server'
-      $server_version        = '5.5.28-6'
-      $shared_package_name   = 'MySQL-shared'
-      $shared_version        = '5.5.28_wsrep_23.7'
+      case $::operatingsystem {
+        'RedHat': {
+          $client_package_name   = 'mysql'
+          $client_version        = '5.1.69-1'
+          $server_package_name   = 'mysql-server'
+          $server_version        = '5.1.69-1'
+          $shared_package_name   = 'mysql-libs'
+          $shared_version        = '5.1.69-1'
+        }
+        default: {
+          $client_package_name   = 'MySQL-client'
+          $client_version        = '5.5.28-6'
+          $server_package_name   = 'MySQL-server'
+          $server_version        = '5.5.28-6'
+          $shared_package_name   = 'MySQL-shared'
+          $shared_version        = '5.5.28_wsrep_23.7'
+        }
+      }
       $socket                = '/var/lib/mysql/mysql.sock'
       $pidfile               = '/var/run/mysqld/mysqld.pid'
       $config_file           = '/etc/my.cnf'

--- a/deployment/puppet/mysql/manifests/params.pp
+++ b/deployment/puppet/mysql/manifests/params.pp
@@ -33,21 +33,21 @@ class mysql::params {
       $service_name          = 'mysql'
       case $::operatingsystem {
         'RedHat': {
-          $client_package_name   = 'mysql'
-          $client_version        = '5.1.69-1'
-          $server_package_name   = 'mysql-server'
-          $server_version        = '5.1.69-1'
-          $shared_package_name   = 'mysql-libs'
-          $shared_version        = '5.1.69-1'
-        }
-        default: {
-          $client_package_name   = 'MySQL-client'
-          $client_version        = '5.5.28-6'
-          $server_package_name   = 'MySQL-server'
-          $server_version        = '5.5.28-6'
-          $shared_package_name   = 'MySQL-shared'
-          $shared_version        = '5.5.28_wsrep_23.7'
-        }
+           $client_package_name   = 'mysql'
+           $client_version        = '5.1.69-1'
+           $server_package_name   = 'mysql-server'
+           $server_version        = '5.1.69-1'
+           $shared_package_name   = 'mysql-libs'
+           $shared_version        = '5.1.69-1'
+         }
+      default: {
+           $client_package_name   = 'MySQL-client'
+           $client_version        = '5.5.28-6'
+           $server_package_name   = 'MySQL-server'
+           $server_version        = '5.5.28-6'
+           $shared_package_name   = 'MySQL-shared'
+           $shared_version        = '5.5.28_wsrep_23.7'
+         }
       }
       $socket                = '/var/lib/mysql/mysql.sock'
       $pidfile               = '/var/run/mysqld/mysqld.pid'

--- a/deployment/puppet/mysql/manifests/server.pp
+++ b/deployment/puppet/mysql/manifests/server.pp
@@ -98,7 +98,13 @@ class mysql::server (
 
     package { 'mysql-server':
       name   => $package_name,
+    } ->
+    exec { "create-mysql-table-if-missing": 
+      command => "/usr/bin/mysql_install_db --datadir=$mysql::params::datadir --user=mysql && chown -R mysql:mysql $mysql::params::datadir",
+      path => '/bin:/usr/bin:/sbin:/usr/sbin',
+      unless => 'test -d $mysl::params::datadir',
     }
+
 
  
     Class['openstack::corosync'] -> Cs_resource['p_mysql']

--- a/deployment/puppet/rpmcache/templates/build_rpm_cache.erb
+++ b/deployment/puppet/rpmcache/templates/build_rpm_cache.erb
@@ -8,7 +8,7 @@ subscription-manager attach "--pool=$poolid"
 
 #Enable channels
 for channel in <%= rh_base_channels %> <%= rh_openstack_channel %>; do
-  yum-config-manager --enable "$channel"
+  yum-config-manager --enable "$channel" &> /dev/null
 done
 
 #Tell RHSM to let CentOS accept packages from Red Hat


### PR DESCRIPTION
FuelWeb sets hostname to controller-1.mirantis.com. Puppet fact $hostname is just "controller-1". It breaks corosync commands that rely on hostname, so we need a workaround.
Added  &>/dev/null for rpm build cache because of rsyslog rate limiting
