### PR TITLE
Syslog message format fuelweb compatibility fixes

### DIFF
--- a/deployment/puppet/cinder/templates/logging.conf.erb
+++ b/deployment/puppet/cinder/templates/logging.conf.erb
@@ -15,10 +15,10 @@ propagate = 1
 #qualname = cinder
 
 [formatter_debug]
-format = cinder-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = cinder-%(name)s: %(levelname)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/cinder-all.log

--- a/deployment/puppet/glance/templates/logging.conf.erb
+++ b/deployment/puppet/glance/templates/logging.conf.erb
@@ -15,10 +15,10 @@ propagate = 1
 #qualname = glance
 
 [formatter_debug]
-format = glance-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = glance-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = glance-%(name)s: %(levelname)s %(message)s
+format = glance-%(name)s %(levelname)s: %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/glance-all.log

--- a/deployment/puppet/keystone/templates/logging.conf.erb
+++ b/deployment/puppet/keystone/templates/logging.conf.erb
@@ -15,10 +15,10 @@ propagate = 1
 #qualname = keystone
 
 [formatter_debug]
-format = keystone-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = keystone-%(name)s: %(levelname)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/keystone-all.log

--- a/deployment/puppet/nailgun/manifests/init.pp
+++ b/deployment/puppet/nailgun/manifests/init.pp
@@ -90,7 +90,8 @@ class nailgun(
     limitsize      => '100M',
     port           => '514',
     proto          => 'udp',
-    show_timezone  => false,
+    # use date-rfc3339 timestamps
+    show_timezone  => true,
     virtual        => true,
   }
 

--- a/deployment/puppet/nova/templates/logging.conf.erb
+++ b/deployment/puppet/nova/templates/logging.conf.erb
@@ -15,10 +15,10 @@ propagate = 1
 #qualname = nova
 
 [formatter_debug]
-format = nova-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = nova-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = nova-%(name)s: %(levelname)s %(message)s
+format = nova-%(name)s %(levelname)s: %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/nova-all.log

--- a/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
@@ -338,7 +338,6 @@ if ($cinder) {
 ### CINDER/VOLUME END ###
 
 ### GLANCE and SWIFT ###
-
 # Which backend to use for glance
 # Supported backends are "swift" and "file"
 $glance_backend          = 'swift'
@@ -400,7 +399,8 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    # use date-rfc3339 timestamps
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
@@ -438,7 +438,8 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    # use date-rfc3339 timestamps
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
@@ -461,7 +461,8 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    # use date-rfc3339 timestamps
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
@@ -401,7 +401,8 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    # use date-rfc3339 timestamps
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_simple.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_simple.pp
@@ -341,7 +341,8 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    # use date-rfc3339 timestamps
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/openstack/examples/site_openstack_single.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_single.pp
@@ -306,7 +306,8 @@ if $use_syslog {
   class { "::openstack::logging":
     stage          => 'first',
     role           => 'client',
-    show_timezone => false,
+    # use date-rfc3339 timestamps
+    show_timezone => true,
     # log both locally include auth, and remote
     log_remote     => true,
     log_local      => true,

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -25,13 +25,13 @@ propagate = 1
 keys = normal,debug,default
 
 [formatter_debug]
-format = quantum-%(name)s: %(levelname)s %(module)s %(funcName)s %(message)s
+format = quantum-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = quantum-%(name)s: %(levelname)s %(message)s
+format = quantum-%(name)s %(levelname)s: %(message)s
 
 [formatter_default]
-format=%(asctime)s %(levelname)s %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s
+format=%(asctime)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/quantum-all.log


### PR DESCRIPTION
Syslog message format fuelweb compatibility fixes
- Add semicolon after severity
- Use date-rfc3339 for rsyslog server
