### PR TITLE
Treat koji OSCI as test internal repo controlled by enable_test_repo

### DIFF
--- a/deployment/puppet/openstack/manifests/mirantis_repos.pp
+++ b/deployment/puppet/openstack/manifests/mirantis_repos.pp
@@ -78,7 +78,7 @@ class openstack::mirantis_repos (
 
       # Below we set our internal repos for testing purposes. Some of them may match with external ones.
       if $type == 'custom' {
-        
+
         apt::pin { 'precise-fuel-grizzly':
           order      => 19,
           priority   => 1001,
@@ -162,7 +162,7 @@ class openstack::mirantis_repos (
 
       # added internal (custom)/external (default) network mirror
       if $type == 'default' {
-        
+
         yumrepo { 'centos-base':
             descr      => 'Mirantis-CentOS-Base',
             name       => 'base',
@@ -172,6 +172,7 @@ class openstack::mirantis_repos (
             mirrorlist => absent,
         }
 
+	if $enable_test_repo {
         yumrepo { 'openstack-koji-fuel-grizzly':
             descr      => 'Mirantis OpenStack grizzly Custom Packages',
             baseurl    => 'http://osci-koji.srt.mirantis.net/mash/fuel-3.0-testing/x86_64',
@@ -179,7 +180,8 @@ class openstack::mirantis_repos (
             gpgkey     => 'http://download.mirantis.com/epel-fuel-grizzly/mirantis.key',
             mirrorlist => absent,
         }
-        
+	}
+
         yumrepo { 'openstack-epel-fuel-grizzly':
             descr      => 'Mirantis OpenStack grizzly Custom Packages',
             baseurl    => 'http://download.mirantis.com/epel-fuel-grizzly-3.1',
@@ -187,7 +189,7 @@ class openstack::mirantis_repos (
             gpgkey     => 'http://download.mirantis.com/epel-fuel-grizzly-3.1/mirantis.key',
             mirrorlist => absent,
         }
-        
+
       # completely disable additional out-of-box repos
         yumrepo { 'extras':
                 descr => 'CentOS-$releasever - Extras',


### PR DESCRIPTION
Any internal urls should be used only if enable_test_repo is True

Signed-off-by: Bogdan Dobrelya bogdando@mail.ru
