### PR TITLE
Add /var/log/syslog to time based rotation as well

### DIFF
--- a/deployment/puppet/openstack/templates/10-fuel.conf.erb
+++ b/deployment/puppet/openstack/templates/10-fuel.conf.erb
@@ -1,5 +1,5 @@
 "/var/log/*-all.log" "/var/log/remote/*/*log"
-"/var/log/kern.log" "/var/log/debug" "/var/log/daemon.log"
+"/var/log/kern.log" "/var/log/debug" "/var/log/syslog" "/var/log/daemon.log"
 "/var/log/auth.log" "/var/log/user.log" "var/log/mail.log"
 "/var/log/cron.log" "/var/log/dashboard.log" "/var/log/ha.log"
 {


### PR DESCRIPTION
/var/log/syslog was initially added to size based rotaion plan (20-fuel.conf) only.
Should be added to time based rotation plan (10-fuel.conf) as well.

Signed-off-by: Bogdan Dobrelya bogdando@mail.ru
