### PR TITLE
Fix logclient

### DIFF
--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -4,8 +4,7 @@
 # $osapi_volume_extension = cinder.api.openstack.volume.contrib.standard_extensions
 # $root_helper = sudo /usr/local/bin/cinder-rootwrap /etc/cinder/rootwrap.conf
 # $use_syslog = Rather or not service should log to syslog. Optional.
-# $syslog_log_facility = Facility for syslog, if used. Optional. Note: duplicating conf option
-#       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
+# $syslog_log_facility = Facility for syslog, if used. Optional.
 # $syslog_log_level = logging level for non verbose and non debug mode. Optional.
 
 class cinder::base (
@@ -58,27 +57,45 @@ class cinder::base (
     require => Package['cinder'],
   }
 
-if $use_syslog {
+  cinder_config {
+    'DEFAULT/log_file':   ensure=> absent;
+    'DEFAULT/log_dir':    ensure=> absent;
+    'DEFAULT/logfile':   ensure=> absent;
+    'DEFAULT/logdir':    ensure=> absent;
+  }
+
+if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
   cinder_config {
     'DEFAULT/log_config': value => "/etc/cinder/logging.conf";
-    'DEFAULT/log_file': ensure=> absent;
-    'DEFAULT/logdir': ensure=> absent;
+    'DEFAULT/use_stderr': ensure=> absent;
+    'DEFAULT/use_syslog': value => true;
+    'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
   }
   file { "cinder-logging.conf":
     content => template('cinder/logging.conf.erb'),
     path => "/etc/cinder/logging.conf",
     require => File[$::cinder::params::cinder_conf],
   }
-
+}
+else {
+  # logging for agents grabbing from stderr
+  cinder_config {
+    'DEFAULT/log_config': ensure=> absent;
+    'DEFAULT/use_syslog': ensure=> absent;
+    'DEFAULT/syslog_log_facility': ensure=> absent;
+    'DEFAULT/use_stderr': value => true;
+  }
+  # might be used for stdout logging instead, if configured
+  file { "cinder-logging.conf":
+    content => template('cinder/logging.conf-nosyslog.erb'),
+    path => "/etc/cinder/logging.conf",
+    require => File[$::cinder::params::cinder_conf],
+  }
+}
   # We must notify services to apply new logging rules
   File['cinder-logging.conf'] ~> Service<| title == 'cinder-api' |>
   File['cinder-logging.conf'] ~> Service<| title == 'cinder-volume' |>
   File['cinder-logging.conf'] ~> Service<| title == 'cinder-scheduler' |>
-
-}
-else {
-	cinder_config {'DEFAULT/log_config': ensure=>absent;}
-}
 
   file { $::cinder::params::cinder_conf: }
   file { $::cinder::params::cinder_paste_api_ini: }
@@ -138,7 +155,6 @@ else {
     'DEFAULT/debug':               value => $debug;
     'DEFAULT/verbose':             value => $verbose;
     'DEFAULT/api_paste_config':    value => '/etc/cinder/api-paste.ini';
-    'DEFAULT/use_syslog':          value => $use_syslog;
   }
   exec { 'cinder-manage db_sync':
     command     => $::cinder::params::db_sync_command,

--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -95,9 +95,9 @@ else {
   }
 }
   # We must notify services to apply new logging rules
-  File['cinder-logging.conf'] ~> Service<| title == 'cinder-api' |>
-  File['cinder-logging.conf'] ~> Service<| title == 'cinder-volume' |>
-  File['cinder-logging.conf'] ~> Service<| title == 'cinder-scheduler' |>
+  File['cinder-logging.conf'] ~> Service<| title == 'openstack-cinder-api' |>
+  File['cinder-logging.conf'] ~> Service<| title == 'openstack-cinder-volume' |>
+  File['cinder-logging.conf'] ~> Service<| title == 'openstack-cinder-scheduler' |>
 
   file { $::cinder::params::cinder_conf: }
   file { $::cinder::params::cinder_paste_api_ini: }

--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -57,16 +57,13 @@ class cinder::base (
     require => Package['cinder'],
   }
 
+if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
   cinder_config {
+    'DEFAULT/log_config': value => "/etc/cinder/logging.conf";
     'DEFAULT/log_file':   ensure=> absent;
     'DEFAULT/log_dir':    ensure=> absent;
     'DEFAULT/logfile':   ensure=> absent;
     'DEFAULT/logdir':    ensure=> absent;
-  }
-
-if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
-  cinder_config {
-    'DEFAULT/log_config': value => "/etc/cinder/logging.conf";
     'DEFAULT/use_stderr': ensure=> absent;
     'DEFAULT/use_syslog': value => true;
     'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -78,12 +75,15 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
   }
 }
 else {
-  # logging for agents grabbing from stderr
   cinder_config {
     'DEFAULT/log_config': ensure=> absent;
     'DEFAULT/use_syslog': ensure=> absent;
     'DEFAULT/syslog_log_facility': ensure=> absent;
-    'DEFAULT/use_stderr': value => true;
+    'DEFAULT/use_stderr': ensure=> absent;
+    'DEFAULT/logging_context_format_string':
+     value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+    'DEFAULT/logging_default_format_string':
+     value => '%(asctime)s %(levelname)s %(name)s [-] %(instance)s %(message)s';
   }
   # might be used for stdout logging instead, if configured
   file { "cinder-logging.conf":

--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -29,6 +29,7 @@ class cinder::base (
   $use_syslog             = false,
   $syslog_log_facility    = "LOCAL3",
   $syslog_log_level = 'WARNING',
+  $log_dir                = '/var/log/cinder',
 ) {
 
   include cinder::params
@@ -80,6 +81,7 @@ else {
     'DEFAULT/use_syslog': ensure=> absent;
     'DEFAULT/syslog_log_facility': ensure=> absent;
     'DEFAULT/use_stderr': ensure=> absent;
+    'DEFAULT/logdir':value=> $log_dir;
     'DEFAULT/logging_context_format_string':
      value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
     'DEFAULT/logging_default_format_string':

--- a/deployment/puppet/cinder/manifests/base.pp
+++ b/deployment/puppet/cinder/manifests/base.pp
@@ -95,9 +95,9 @@ else {
   }
 }
   # We must notify services to apply new logging rules
-  File['cinder-logging.conf'] ~> Service<| title == 'openstack-cinder-api' |>
-  File['cinder-logging.conf'] ~> Service<| title == 'openstack-cinder-volume' |>
-  File['cinder-logging.conf'] ~> Service<| title == 'openstack-cinder-scheduler' |>
+  File['cinder-logging.conf'] ~> Service<| title == "$::cinder::params::api_service" |>
+  File['cinder-logging.conf'] ~> Service<| title == "$::cinder::params::volume_service" |>
+  File['cinder-logging.conf'] ~> Service<| title == "$::cinder::params::scheduler_service" |>
 
   file { $::cinder::params::cinder_conf: }
   file { $::cinder::params::cinder_paste_api_ini: }
@@ -170,7 +170,7 @@ else {
   Cinder_config<||> -> Exec['cinder-manage db_sync']
   Nova_config<||> -> Exec['cinder-manage db_sync']
   Cinder_api_paste_ini<||> -> Exec['cinder-manage db_sync']
- Exec['cinder-manage db_sync'] -> Service<| title == 'cinder-api' |>
- Exec['cinder-manage db_sync'] -> Service<| title == 'cinder-volume' |>
- Exec['cinder-manage db_sync'] -> Service<| title == 'cinder-scheduler' |>
+ Exec['cinder-manage db_sync'] -> Service<| title == $::cinder::params::api_service |>
+ Exec['cinder-manage db_sync'] -> Service<| title == $::cinder::params::volume_service |>
+ Exec['cinder-manage db_sync'] -> Service<| title == $::cinder::params::scheduler_service |>
 }

--- a/deployment/puppet/cinder/templates/logging.conf-nosyslog.erb
+++ b/deployment/puppet/cinder/templates/logging.conf-nosyslog.erb
@@ -1,0 +1,24 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = root
+
+[formatters]
+keys = default
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s
+
+
+[logger_root]
+level=NOTSET
+handlers = root
+propagate = 1
+
+
+[handler_root]
+class = StreamHandler
+level=NOTSET
+formatter = default
+args = (sys.stdout,)

--- a/deployment/puppet/cinder/templates/logging.conf.erb
+++ b/deployment/puppet/cinder/templates/logging.conf.erb
@@ -13,13 +13,12 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = cinder-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = cinder-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = cinder-%(name)s %(levelname)s: %(module)s %(message)s
+format = cinder-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/cinder-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>

--- a/deployment/puppet/cinder/templates/logging.conf.erb
+++ b/deployment/puppet/cinder/templates/logging.conf.erb
@@ -13,10 +13,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = cinder-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = cinder-%(name)s %(levelname)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/cinder/templates/logging.conf.erb
+++ b/deployment/puppet/cinder/templates/logging.conf.erb
@@ -1,24 +1,22 @@
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
 [formatters]
 keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = cinder
 
 [formatter_debug]
-format = cinder-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
+format = cinder-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = cinder-%(name)s %(levelname)s: %(message)s
+format = cinder-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/cinder-all.log
@@ -26,16 +24,41 @@ format = cinder-%(name)s %(levelname)s: %(message)s
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
 formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
 args = (sys.stdout,)

--- a/deployment/puppet/glance/manifests/api.pp
+++ b/deployment/puppet/glance/manifests/api.pp
@@ -111,6 +111,7 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
    'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/log_file':value=> $log_file;
    'DEFAULT/logging_context_format_string':
     value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
    'DEFAULT/logging_default_format_string':

--- a/deployment/puppet/glance/manifests/api.pp
+++ b/deployment/puppet/glance/manifests/api.pp
@@ -88,16 +88,13 @@ class glance::api(
     fail("Invalid db connection ${sql_connection}")
   }
 
+if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
  glance_api_config {
+   'DEFAULT/log_config': value => "/etc/glance/logging.conf";
    'DEFAULT/log_file': ensure=> absent;
    'DEFAULT/log_dir': ensure=> absent;
    'DEFAULT/logfile':   ensure=> absent;
    'DEFAULT/logdir':    ensure=> absent;
- }
-
-if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
- glance_api_config {
-   'DEFAULT/log_config': value => "/etc/glance/logging.conf";
    'DEFAULT/use_stderr':  ensure=> absent;
    'DEFAULT/use_syslog':  value => true;
    'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -110,11 +107,14 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
  }
 } else {
  glance_api_config {
-   # logging for agents grabbing from stderr
    'DEFAULT/log_config': ensure=> absent;
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
-   'DEFAULT/use_stderr': value => true;
+   'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/logging_context_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+   'DEFAULT/logging_default_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [-] %(instance)s %(message)s';
  }
  # might be used for stdout logging instead, if configured
    if !defined(File["glance-logging.conf"]) {

--- a/deployment/puppet/glance/manifests/registry.pp
+++ b/deployment/puppet/glance/manifests/registry.pp
@@ -54,6 +54,7 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
    'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/log_file':value=>$log_file;
    'DEFAULT/logging_context_format_string':
     value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
    'DEFAULT/logging_default_format_string':

--- a/deployment/puppet/glance/manifests/registry.pp
+++ b/deployment/puppet/glance/manifests/registry.pp
@@ -31,16 +31,13 @@ File {
   require => Class['glance']
 }
 
-glance_registry_config {
+if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
+ glance_registry_config {
+   'DEFAULT/log_config': value => "/etc/glance/logging.conf";
    'DEFAULT/log_file': ensure=> absent;
    'DEFAULT/log_dir': ensure=> absent;
    'DEFAULT/logfile':   ensure=> absent;
    'DEFAULT/logdir':    ensure=> absent;
-}
-
-if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
- glance_registry_config {
-   'DEFAULT/log_config': value => "/etc/glance/logging.conf";
    'DEFAULT/use_stderr': ensure=> absent;
    'DEFAULT/use_syslog': value => true;
    'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -52,12 +49,15 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
    }
  }
 } else {
-# might be used for stdout logging instead, if configured
  glance_registry_config {
    'DEFAULT/log_config':    ensure=> absent;
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
-   'DEFAULT/use_stderr': value => true;
+   'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/logging_context_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+   'DEFAULT/logging_default_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [-] %(instance)s %(message)s';
  }
  # might be used for stdout logging instead, if configured
  if !defined(File["glance-logging.conf"]) {

--- a/deployment/puppet/glance/templates/logging.conf-nosyslog.erb
+++ b/deployment/puppet/glance/templates/logging.conf-nosyslog.erb
@@ -1,0 +1,24 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = root
+
+[formatters]
+keys = default
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s
+
+
+[logger_root]
+level=NOTSET
+handlers = root
+propagate = 1
+
+
+[handler_root]
+class = StreamHandler
+level=NOTSET
+formatter = default
+args = (sys.stdout,)

--- a/deployment/puppet/glance/templates/logging.conf.erb
+++ b/deployment/puppet/glance/templates/logging.conf.erb
@@ -13,10 +13,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = glance-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = glance-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = glance-%(name)s %(levelname)s %(message)s
+format = glance-%(name)s %(levelname)s: %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/glance/templates/logging.conf.erb
+++ b/deployment/puppet/glance/templates/logging.conf.erb
@@ -13,13 +13,12 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = glance-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = glance-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = glance-%(name)s %(levelname)s: %(module)s %(message)s
+format = glance-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/glance-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>

--- a/deployment/puppet/glance/templates/logging.conf.erb
+++ b/deployment/puppet/glance/templates/logging.conf.erb
@@ -1,24 +1,22 @@
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
 [formatters]
 keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = glance
 
 [formatter_debug]
-format = glance-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
+format = glance-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = glance-%(name)s %(levelname)s: %(message)s
+format = glance-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/glance-all.log
@@ -26,16 +24,41 @@ format = glance-%(name)s %(levelname)s: %(message)s
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
 formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
 args = (sys.stdout,)

--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -111,6 +111,7 @@ class keystone(
       'DEFAULT/use_syslog': ensure=> absent;
       'DEFAULT/syslog_log_facility': ensure=> absent;
       'DEFAULT/use_stderr': ensure=> absent;
+      'DEFAULT/log_dir':value=> $log_dir;
     }
     # might be used for stdout logging instead, if configured
     file {"keystone-logging.conf":

--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -19,8 +19,7 @@
 #     Defaults to False.
 #   [use_syslog] Rather or not keystone should log to syslog. Optional.
 #     Defaults to False.
-#   [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option
-#     wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
+#   [syslog_log_facility] Facility for syslog, if used. Optional.
 #   [syslog_log_level] logging level for non verbose and non debug mode. Optional.
 #   [catalog_type] Type of catalog that keystone uses to store endpoints,services. Optional.
 #     Defaults to sql. (Also accepts template)
@@ -88,11 +87,19 @@ class keystone(
     require => Package['keystone'],
   }
 
-  if $use_syslog {
+  keystone_config {
+      'DEFAULT/log_file': ensure=> absent;
+      'DEFAULT/log_dir': ensure=> absent;
+      'DEFAULT/logfile':   ensure=> absent;
+      'DEFAULT/logdir':    ensure=> absent;
+  }
+
+  if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
     keystone_config {
       'DEFAULT/log_config': value => "/etc/keystone/logging.conf";
-      'DEFAULT/log_file': ensure=> absent;
-      'DEFAULT/logdir': ensure=> absent;
+      'DEFAULT/use_stderr': ensure=> absent;
+      'DEFAULT/use_syslog': value => true;
+      'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
     }
     file {"keystone-logging.conf":
       content => template('keystone/logging.conf.erb'),
@@ -103,9 +110,19 @@ class keystone(
     }
   } else  {
     keystone_config {
-     'DEFAULT/log_config': ensure => absent;
-     'DEFAULT/log_file': value => $log_file;
-     'DEFAULT/log_dir': value => $log_dir;
+      # logging for agents grabbing from stderr
+      'DEFAULT/log_config': ensure=> absent;
+      'DEFAULT/use_syslog': ensure=> absent;
+      'DEFAULT/syslog_log_facility': ensure=> absent;
+      'DEFAULT/use_stderr': value => true;
+    }
+    # might be used for stdout logging instead, if configured
+    file {"keystone-logging.conf":
+      content => template('keystone/logging.conf.erb'),
+      path => "/etc/keystone/logging.conf",
+      require => File['/etc/keystone'],
+      # We must notify service for new logging rules
+      notify => Service['keystone'],
     }
   }
 
@@ -166,7 +183,6 @@ class keystone(
     'DEFAULT/compute_port': value => $compute_port;
     'DEFAULT/debug':        value => $debug;
     'DEFAULT/verbose':      value => $verbose;
-    'DEFAULT/use_syslog':   value => $use_syslog;
     'identity/driver': value =>"keystone.identity.backends.sql.Identity";
     'token/driver': value =>"keystone.token.backends.sql.Token";
     'policy/driver': value =>"keystone.policy.backends.rules.Policy";

--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -87,16 +87,13 @@ class keystone(
     require => Package['keystone'],
   }
 
-  keystone_config {
+  if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
+    keystone_config {
+      'DEFAULT/log_config': value => "/etc/keystone/logging.conf";
       'DEFAULT/log_file': ensure=> absent;
       'DEFAULT/log_dir': ensure=> absent;
       'DEFAULT/logfile':   ensure=> absent;
       'DEFAULT/logdir':    ensure=> absent;
-  }
-
-  if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
-    keystone_config {
-      'DEFAULT/log_config': value => "/etc/keystone/logging.conf";
       'DEFAULT/use_stderr': ensure=> absent;
       'DEFAULT/use_syslog': value => true;
       'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -110,15 +107,14 @@ class keystone(
     }
   } else  {
     keystone_config {
-      # logging for agents grabbing from stderr
       'DEFAULT/log_config': ensure=> absent;
       'DEFAULT/use_syslog': ensure=> absent;
       'DEFAULT/syslog_log_facility': ensure=> absent;
-      'DEFAULT/use_stderr': value => true;
+      'DEFAULT/use_stderr': ensure=> absent;
     }
     # might be used for stdout logging instead, if configured
     file {"keystone-logging.conf":
-      content => template('keystone/logging.conf.erb'),
+      content => template('keystone/logging.conf-nosyslog.erb'),
       path => "/etc/keystone/logging.conf",
       require => File['/etc/keystone'],
       # We must notify service for new logging rules

--- a/deployment/puppet/keystone/templates/logging.conf-nosyslog.erb
+++ b/deployment/puppet/keystone/templates/logging.conf-nosyslog.erb
@@ -1,0 +1,24 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = root
+
+[formatters]
+keys = default
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s
+
+
+[logger_root]
+level=NOTSET
+handlers = root
+propagate = 1
+
+
+[handler_root]
+class = StreamHandler
+level=NOTSET
+formatter = default
+args = (sys.stdout,)

--- a/deployment/puppet/keystone/templates/logging.conf.erb
+++ b/deployment/puppet/keystone/templates/logging.conf.erb
@@ -13,10 +13,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = keystone-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = keystone-%(name)s %(levelname)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/keystone/templates/logging.conf.erb
+++ b/deployment/puppet/keystone/templates/logging.conf.erb
@@ -1,24 +1,22 @@
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
 [formatters]
 keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = keystone
 
 [formatter_debug]
-format = keystone-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
+format = keystone-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = keystone-%(name)s %(levelname)s: %(message)s
+format = keystone-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/keystone-all.log
@@ -26,16 +24,41 @@ format = keystone-%(name)s %(levelname)s: %(message)s
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
 formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
 args = (sys.stdout,)

--- a/deployment/puppet/keystone/templates/logging.conf.erb
+++ b/deployment/puppet/keystone/templates/logging.conf.erb
@@ -13,13 +13,12 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = keystone-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = keystone-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = keystone-%(name)s %(levelname)s: %(module)s %(message)s
+format = keystone-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/keystone-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>

--- a/deployment/puppet/nova/manifests/init.pp
+++ b/deployment/puppet/nova/manifests/init.pp
@@ -160,13 +160,6 @@ class nova(
     require => Package['nova-common'],
   }
 
-nova_config {
- 'DEFAULT/log_file': ensure=> absent;
- 'DEFAULT/log_dir': ensure=> absent;
- 'DEFAULT/logfile':   ensure=> absent;
- 'DEFAULT/logdir': ensure=> absent;
-}
-
 #Configure logging in nova.conf
 if $use_syslog and !$debug =~ /(?i)(true|yes)/
  {
@@ -174,13 +167,13 @@ if $use_syslog and !$debug =~ /(?i)(true|yes)/
 nova_config
  {
  'DEFAULT/log_config': value => "/etc/nova/logging.conf";
+ 'DEFAULT/log_file': ensure=> absent;
+ 'DEFAULT/log_dir': ensure=> absent;
+ 'DEFAULT/logfile':   ensure=> absent;
+ 'DEFAULT/logdir': ensure=> absent;
  'DEFAULT/use_syslog': value =>  true;
  'DEFAULT/use_stderr': ensure=> absent;
  'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
-# 'DEFAULT/logging_context_format_string':
-#  value => '%(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
-# 'DEFAULT/logging_default_format_string':
-# value =>'%(levelname)s %(name)s [-] %(instance)s %(message)s';
 }
 
 file {"nova-logging.conf":
@@ -191,11 +184,14 @@ file {"nova-logging.conf":
 }
 else {
   nova_config {
-   # logging for agents grabbing from stderr
    'DEFAULT/log_config': ensure=> absent;
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
-   'DEFAULT/use_stderr': value => true;
+   'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/logging_context_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
+   'DEFAULT/logging_default_format_string':
+    value => '%(asctime)s %(levelname)s %(name)s [-] %(instance)s %(message)s';
   }
   # might be used for stdout logging instead, if configured
   file {"nova-logging.conf":

--- a/deployment/puppet/nova/manifests/init.pp
+++ b/deployment/puppet/nova/manifests/init.pp
@@ -168,9 +168,7 @@ nova_config
  {
  'DEFAULT/log_config': value => "/etc/nova/logging.conf";
  'DEFAULT/log_file': ensure=> absent;
- 'DEFAULT/log_dir': ensure=> absent;
  'DEFAULT/logfile':   ensure=> absent;
- 'DEFAULT/logdir': ensure=> absent;
  'DEFAULT/use_syslog': value =>  true;
  'DEFAULT/use_stderr': ensure=> absent;
  'DEFAULT/syslog_log_facility': value =>  $syslog_log_facility;
@@ -188,6 +186,7 @@ else {
    'DEFAULT/use_syslog': ensure=> absent;
    'DEFAULT/syslog_log_facility': ensure=> absent;
    'DEFAULT/use_stderr': ensure=> absent;
+   'DEFAULT/logdir': value=> $logdir;
    'DEFAULT/logging_context_format_string':
     value => '%(asctime)s %(levelname)s %(name)s [%(request_id)s %(user_id)s %(project_id)s] %(instance)s %(message)s';
    'DEFAULT/logging_default_format_string':

--- a/deployment/puppet/nova/templates/logging.conf-nosyslog.erb
+++ b/deployment/puppet/nova/templates/logging.conf-nosyslog.erb
@@ -1,0 +1,24 @@
+[loggers]
+keys = root
+
+[handlers]
+keys = root
+
+[formatters]
+keys = default
+
+[formatter_default]
+format=%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s
+
+
+[logger_root]
+level=NOTSET
+handlers = root
+propagate = 1
+
+
+[handler_root]
+class = StreamHandler
+level=NOTSET
+formatter = default
+args = (sys.stdout,)

--- a/deployment/puppet/nova/templates/logging.conf.erb
+++ b/deployment/puppet/nova/templates/logging.conf.erb
@@ -1,24 +1,22 @@
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
 [formatters]
 keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = nova
 
 [formatter_debug]
-format = nova-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
+format = nova-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = nova-%(name)s %(levelname)s: %(message)s
+format = nova-%(name)s %(levelname)s: %(module)s %(message)s
 
 # Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 # Note: local copy goes to /var/log/nova-all.log
@@ -26,16 +24,41 @@ format = nova-%(name)s %(levelname)s: %(message)s
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
 formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
 args = (sys.stdout,)

--- a/deployment/puppet/nova/templates/logging.conf.erb
+++ b/deployment/puppet/nova/templates/logging.conf.erb
@@ -13,10 +13,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = nova-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = nova-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = nova-%(name)s %(levelname)s %(message)s
+format = nova-%(name)s %(levelname)s: %(message)s
 
 # logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]

--- a/deployment/puppet/nova/templates/logging.conf.erb
+++ b/deployment/puppet/nova/templates/logging.conf.erb
@@ -13,13 +13,12 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = nova-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = nova-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = nova-%(name)s %(levelname)s: %(module)s %(message)s
+format = nova-%(name)s %(levelname)s %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/nova-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>

--- a/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
@@ -381,6 +381,15 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
 $use_syslog = true
@@ -472,15 +481,6 @@ $openstack_version = {
 $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = false
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_compact_fordocs.pp
@@ -432,6 +432,7 @@ if $use_syslog {
     # Rabbit doesn't support syslog directly, should be >= syslog_log_level,
     # otherwise none rabbit's messages would have gone to syslog
     rabbit_log_level => $syslog_log_level,
+    debug => $debug,
   }
 }
 
@@ -688,6 +689,8 @@ node /fuel-controller-[\d+]/ {
     db_host                => $internal_virtual_ip,
     service_endpoint       => $internal_virtual_ip,
     cinder_rate_limits     => $cinder_rate_limits,
+    debug                  => $debug,
+    verbose                => $verbose,
     syslog_log_level       => $syslog_log_level,
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
   }
@@ -705,6 +708,9 @@ node /fuel-controller-[\d+]/ {
     controller_node_address => $internal_virtual_ip,
     swift_local_net_ip      => $swift_local_net_ip,
     master_swift_proxy_ip  => $master_swift_proxy_ip,
+    debug                   => $debug,
+    verbose                 => $verbose,
+    syslog_log_level        => $syslog_log_level,
   }
 
   Class ['openstack::swift::proxy'] -> Class['openstack::swift::storage_node']
@@ -778,6 +784,7 @@ node /fuel-compute-[\d+]/ {
     ssh_public_key         => 'puppet:///ssh_keys/openstack.pub',
     use_syslog             => $use_syslog,
     syslog_log_level       => $syslog_log_level,
+    syslog_log_facility    => $syslog_log_facility_nova,
     syslog_log_facility_quantum => $syslog_log_facility_quantum,
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
     nova_rate_limits       => $nova_rate_limits,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
@@ -420,6 +420,15 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
 $use_syslog = true
@@ -511,15 +520,6 @@ $openstack_version = {
 $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = true
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_compact.pp
@@ -471,6 +471,7 @@ if $use_syslog {
     # Rabbit doesn't support syslog directly, should be >= syslog_log_level,
     # otherwise none rabbit's messages would have gone to syslog
     rabbit_log_level => $syslog_log_level,
+    debug => $debug,
   }
 }
 
@@ -761,6 +762,8 @@ node /fuel-controller-[\d+]/ {
     rabbit_password        => $rabbit_password,
     rabbit_user            => $rabbit_user,
     rabbit_ha_virtual_ip   => $internal_virtual_ip,
+    debug                  => $debug,
+    verbose                => $verbose,
     syslog_log_level       => $syslog_log_level,
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
     qpid_nodes             => [$internal_virtual_ip],
@@ -781,6 +784,9 @@ node /fuel-controller-[\d+]/ {
     controller_node_address => $internal_virtual_ip,
     swift_local_net_ip      => $swift_local_net_ip,
     master_swift_proxy_ip  => $master_swift_proxy_ip,
+    debug                   => $debug,
+    verbose                 => $verbose,
+    syslog_log_level        => $syslog_log_level,
   }
 
   Class ['openstack::swift::proxy'] -> Class['openstack::swift::storage_node']
@@ -857,6 +863,7 @@ node /fuel-compute-[\d+]/ {
     ssh_public_key         => 'puppet:///ssh_keys/openstack.pub',
     use_syslog             => $use_syslog,
     syslog_log_level       => $syslog_log_level,
+    syslog_log_facility    => $syslog_log_facility_nova,
     syslog_log_facility_quantum => $syslog_log_facility_quantum,
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
     nova_rate_limits       => $nova_rate_limits,

--- a/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
@@ -443,6 +443,15 @@ $master_swift_proxy_ip = $master_swift_proxy_nodes[0]['internal_address']
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
 $use_syslog = true
@@ -534,15 +543,6 @@ $openstack_version = {
 $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = false
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_full.pp
@@ -494,6 +494,7 @@ if $use_syslog {
     # Rabbit doesn't support syslog directly, should be >= syslog_log_level,
     # otherwise none rabbit's messages would have gone to syslog
     rabbit_log_level => $syslog_log_level,
+    debug => $debug,
   }
 }
 
@@ -833,6 +834,7 @@ node /fuel-compute-[\d+]/ {
     ssh_public_key         => 'puppet:///ssh_keys/openstack.pub',
     use_syslog             => $use_syslog,
     syslog_log_level       => $syslog_log_level,
+    syslog_log_facility    => $syslog_log_facility_nova,
     syslog_log_facility_quantum => $syslog_log_facility_quantum,
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
     nova_rate_limits       => $nova_rate_limits,
@@ -888,7 +890,9 @@ node /fuel-swift-[\d+]/ {
     qpid_user              => $rabbit_user,
     qpid_nodes             => [$internal_virtual_ip],
     sync_rings             => ! $primary_proxy,
-    syslog_log_level => $syslog_log_level,
+    debug                  => $debug,
+    verbose                => $verbose,
+    syslog_log_level       => $syslog_log_level,
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
   }
 
@@ -931,6 +935,9 @@ node /fuel-swiftproxy-[\d+]/ {
     controller_node_address => $internal_virtual_ip,
     swift_local_net_ip      => $swift_local_net_ip,
     master_swift_proxy_ip   => $master_swift_proxy_ip,
+    debug                   => $debug,
+    verbose                 => $verbose,
+    syslog_log_level        => $syslog_log_level,
   }
 }
 

--- a/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
@@ -382,6 +382,14 @@ if $node[0]['role'] == 'primary-controller' {
   $primary_controller = false
 }
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
 
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
@@ -474,15 +482,6 @@ $openstack_version = {
 $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = true
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_ha_minimal.pp
@@ -433,6 +433,7 @@ if $use_syslog {
     # Rabbit doesn't support syslog directly, should be >= syslog_log_level,
     # otherwise none rabbit's messages would have gone to syslog
     rabbit_log_level => $syslog_log_level,
+    debug => $debug,
   }
 }
 

--- a/deployment/puppet/openstack/examples/site_openstack_simple.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_simple.pp
@@ -322,6 +322,15 @@ $swift_loopback = false
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case,
 # and configured to start at the very beginning of puppet agent run.
@@ -414,15 +423,6 @@ $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
 $use_upstream_mysql = true
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = true
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/examples/site_openstack_simple.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_simple.pp
@@ -374,6 +374,7 @@ if $use_syslog {
     # Rabbit doesn't support syslog directly, should be >= syslog_log_level,
     # otherwise none rabbit's messages would have gone to syslog
     rabbit_log_level => $syslog_log_level,
+    debug => $debug,
   }
 }
 
@@ -706,6 +707,7 @@ node /fuel-compute-[\d+]/ {
     cinder_iscsi_bind_addr => $cinder_iscsi_bind_addr,
     use_syslog             => $use_syslog,
     syslog_log_level       => $syslog_log_level,
+    syslog_log_facility    => $syslog_log_facility_nova,
     syslog_log_facility_quantum => $syslog_log_facility_quantum,
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
     nova_rate_limits       => $nova_rate_limits,

--- a/deployment/puppet/openstack/examples/site_openstack_single.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_single.pp
@@ -339,6 +339,7 @@ if $use_syslog {
     # Rabbit doesn't support syslog directly, should be >= syslog_log_level,
     # otherwise none rabbit's messages would have gone to syslog
     rabbit_log_level => $syslog_log_level,
+    debug => $debug,
   }
 }
 

--- a/deployment/puppet/openstack/examples/site_openstack_single.pp
+++ b/deployment/puppet/openstack/examples/site_openstack_single.pp
@@ -287,6 +287,15 @@ $swift_loopback = false
 
 ### Glance and swift END ###
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
+
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case,
 # and configured to start at the very beginning of puppet agent run.
@@ -379,15 +388,6 @@ $mirror_type = 'default'
 $enable_test_repo = false
 $repo_proxy = undef
 $use_upstream_mysql = true
-
-# This parameter specifies the verbosity level of log messages
-# in openstack components config.
-# Debug would have set DEBUG level and ignore verbose settings, if any.
-# Verbose would have set INFO level messages
-# In case of non debug and non verbose - WARNING, default level would have set.
-# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
-$verbose = true
-$debug = false
 
 #Rate Limits for cinder and Nova
 #Cinder and Nova can rate-limit your requests to API services.

--- a/deployment/puppet/openstack/manifests/logging.pp
+++ b/deployment/puppet/openstack/manifests/logging.pp
@@ -18,6 +18,7 @@
 # [virtual] if node is virtual, fix for udp checksums should be applied
 # [rabbit_log_level] should be >= global syslog_log_level option,
 #   otherwise none messages would have gone to syslog (client role only)
+# [debug] switch between debug and standard cases, client role only. imfile monitors for local logs would be used if debug.
 
 class openstack::logging (
     $role           = 'client',
@@ -38,6 +39,7 @@ class openstack::logging (
     $syslog_log_facility_nova     = 'LOCAL6',
     $syslog_log_facility_keystone = 'LOCAL7',
     $rabbit_log_level = 'NOTICE',
+    $debug          = false,
 ) {
 
 validate_re($proto, 'tcp|udp')
@@ -58,6 +60,7 @@ if $role == 'client' {
     syslog_log_facility_nova => $syslog_log_facility_nova,
     syslog_log_facility_keystone => $syslog_log_facility_keystone,
     log_level      => $rabbit_log_level,
+    debug          => $debug,
   }
 
 } else { # server

--- a/deployment/puppet/openstack/manifests/nova/controller.pp
+++ b/deployment/puppet/openstack/manifests/nova/controller.pp
@@ -179,12 +179,13 @@ class openstack::nova::controller (
           image_service        => 'nova.image.glance.GlanceImageService',
           glance_api_servers   => $glance_connection,
           verbose              => $verbose,
+          debug                => $debug,
           rabbit_nodes         => $rabbit_nodes,
           ensure_package       => $ensure_package,
           api_bind_address     => $api_bind_address,
           use_syslog           => $use_syslog,
-      syslog_log_facility  => $syslog_log_facility,
-      syslog_log_level     => $syslog_log_level,
+          syslog_log_facility  => $syslog_log_facility,
+          syslog_log_level     => $syslog_log_level,
           rabbit_ha_virtual_ip => $rabbit_ha_virtual_ip,
         }
       } else {
@@ -195,11 +196,12 @@ class openstack::nova::controller (
           image_service      => 'nova.image.glance.GlanceImageService',
           glance_api_servers => $glance_connection,
           verbose            => $verbose,
+          debug              => $debug,
           rabbit_host        => $rabbit_connection,
           ensure_package     => $ensure_package,
           api_bind_address   => $api_bind_address,
-      syslog_log_facility  => $syslog_log_facility,
-      syslog_log_level     => $syslog_log_level,
+          syslog_log_facility => $syslog_log_facility,
+          syslog_log_level   => $syslog_log_level,
           use_syslog         => $use_syslog,
         }
       }
@@ -214,10 +216,11 @@ class openstack::nova::controller (
         image_service      => 'nova.image.glance.GlanceImageService',
         glance_api_servers => $glance_connection,
         verbose            => $verbose,
+        debug              => $debug,
         ensure_package     => $ensure_package,
         api_bind_address   => $api_bind_address,
-      syslog_log_facility  => $syslog_log_facility,
-      syslog_log_level     => $syslog_log_level,
+        syslog_log_facility => $syslog_log_facility,
+        syslog_log_level   => $syslog_log_level,
         use_syslog         => $use_syslog,
       }
     }
@@ -326,7 +329,7 @@ class openstack::nova::controller (
   }
 
   # Do not enable it!!!!!
-  # metadata service provides by nova api 
+  # metadata service provides by nova api
   # while enabled_apis=ec2,osapi_compute,metadata
   # and by quantum-metadata-agent on network node as proxy
   #

--- a/deployment/puppet/openstack/manifests/swift/proxy.pp
+++ b/deployment/puppet/openstack/manifests/swift/proxy.pp
@@ -37,6 +37,9 @@ class openstack::swift::proxy (
   $master_swift_proxy_ip    = undef,
   $collect_exported         = false,
   $rings                    = ['account', 'object', 'container'],
+  $debug                    = false,
+  $verbose                  = true,
+  $syslog_log_level         = 'WARNING',
 ) {
   if !defined(Class['swift']) {
     class { 'swift':
@@ -57,6 +60,9 @@ class openstack::swift::proxy (
     allow_account_management => $proxy_allow_account_management,
     account_autocreate       => $proxy_account_autocreate,
     package_ensure           => $package_ensure,
+    debug                    => $debug,
+    verbose                  => $verbose,
+    syslog_log_level         => $syslog_log_level,
   }
 
   # configure all of the middlewares

--- a/deployment/puppet/openstack/manifests/swift/storage_node.pp
+++ b/deployment/puppet/openstack/manifests/swift/storage_node.pp
@@ -33,7 +33,9 @@ class openstack::swift::storage_node (
   $service_endpoint       = '127.0.0.1',
   $use_syslog             = false,
   $syslog_log_facility_cinder = 'LOCAL3',
-  $syslog_log_level = 'WARNING',
+  $syslog_log_level       = 'WARNING',
+  $debug                  = false,
+  $verbose                = true,
   # Rabbit details necessary for cinder
   $rabbit_nodes           = false,
   $rabbit_password        = 'rabbit_pw',
@@ -68,6 +70,9 @@ class openstack::swift::storage_node (
     devices              => $storage_mnt_base_dir,
     devices_dirs         => $storage_devices,
     swift_zone           => $swift_zone,
+    debug                => $debug,
+    verbose              => $verbose,
+    syslog_log_level     => $syslog_log_level,
   }
 
   validate_string($master_swift_proxy_ip)

--- a/deployment/puppet/openstack/templates/10-fuel.conf.erb
+++ b/deployment/puppet/openstack/templates/10-fuel.conf.erb
@@ -1,5 +1,5 @@
-"/var/log/*-all.log" "/var/log/remote/*/*log"
-"/var/log/kern.log" "/var/log/debug" "/var/log/daemon.log"
+"/var/log/*-all.log" "/var/log/corosync.log" "/var/log/remote/*/*log"
+"/var/log/kern.log" "/var/log/debug" "/var/log/syslog" "/var/log/daemon.log"
 "/var/log/auth.log" "/var/log/user.log" "var/log/mail.log"
 "/var/log/cron.log" "/var/log/dashboard.log" "/var/log/ha.log"
 {

--- a/deployment/puppet/openstack/templates/20-fuel.conf.erb
+++ b/deployment/puppet/openstack/templates/20-fuel.conf.erb
@@ -1,6 +1,8 @@
 "/var/log/*-all.log" "/var/log/remote/*/*log"
 "/var/log/kern.log" "/var/log/debug" "/var/log/syslog"
 "/var/log/dashboard.log" "/var/log/ha.log" "/var/log/quantum/*.log"
+"/var/log/nova/*.log" "/var/log/keystone/*.log" "/var/log/glance/*.log"
+"/var/log/cinder/*.log"
 # This file is used for hourly log rotations, use (min)size options here
 {
   sharedscripts

--- a/deployment/puppet/openstack/templates/20-fuel.conf.erb
+++ b/deployment/puppet/openstack/templates/20-fuel.conf.erb
@@ -10,7 +10,7 @@
   copytruncate
   # rotate only if 30M size or bigger
   minsize 30M
-  # also rotate if 300M size have exceeded, should be size > minsize
+  # also rotate if <%= @limitsize %> size have exceeded, should be size > minsize
   size <%= @limitsize %>
   # keep logs for <%= @keep %> rotations
   rotate <%= @keep %>

--- a/deployment/puppet/openstack/templates/20-fuel.conf.erb
+++ b/deployment/puppet/openstack/templates/20-fuel.conf.erb
@@ -1,4 +1,4 @@
-"/var/log/*-all.log" "/var/log/remote/*/*log"
+"/var/log/*-all.log" "/var/log/corosync.log" "/var/log/remote/*/*log"
 "/var/log/kern.log" "/var/log/debug" "/var/log/syslog"
 "/var/log/dashboard.log" "/var/log/ha.log" "/var/log/quantum/*.log"
 "/var/log/nova/*.log" "/var/log/keystone/*.log" "/var/log/glance/*.log"

--- a/deployment/puppet/osnailyfacter/examples/site.pp
+++ b/deployment/puppet/osnailyfacter/examples/site.pp
@@ -52,6 +52,14 @@ if $nodes != undef {
   }
 }
 
+# This parameter specifies the verbosity level of log messages
+# in openstack components config.
+# Debug would have set DEBUG level and ignore verbose settings, if any.
+# Verbose would have set INFO level messages
+# In case of non debug and non verbose - WARNING, default level would have set.
+# Note: if syslog on, this default level may be configured (for syslog) with syslog_log_level option.
+$verbose = true
+$debug = false
 
 ### Syslog ###
 # Enable error messages reporting to rsyslog. Rsyslog must be installed in this case.
@@ -126,7 +134,7 @@ class node_netconfig (
 }
 
 case $::operatingsystem {
-  'redhat' : { 
+  'redhat' : {
           $queue_provider = 'qpid'
           $custom_mysql_setup_class = 'pacemaker_mysql'
   }
@@ -185,7 +193,7 @@ class os_common {
       # should be > 30M
       limitsize      => '300M',
       # remote servers to send logs to
-      rservers       => $rservers, 
+      rservers       => $rservers,
       # should be true, if client is running at virtual node
       virtual        => true,
       # facilities
@@ -197,16 +205,18 @@ class os_common {
       # Rabbit doesn't support syslog directly, should be >= syslog_log_level,
       # otherwise none rabbit's messages would have gone to syslog
       rabbit_log_level => $syslog_log_level,
+      # debug mode
+      debug          => $debug ? { 'true' => true, true => true, default=> false },
     }
   }
 
   #case $role {
-    #    /controller/:          { $hostgroup = 'controller' } 
+    #    /controller/:          { $hostgroup = 'controller' }
     #    /swift-proxy/: { $hostgroup = 'swift-proxy' }
     #    /storage/:{ $hostgroup = 'swift-storage'  }
     #    /compute/: { $hostgroup = 'compute'  }
     #    /cinder/: { $hostgroup = 'cinder'  }
-    #    default: { $hostgroup = 'generic' } 
+    #    default: { $hostgroup = 'generic' }
     #}
 
     #  if $nagios != 'false' {
@@ -236,11 +246,11 @@ class os_common {
 
 node default {
   case $deployment_mode {
-    "singlenode": { 
-      include "osnailyfacter::cluster_simple" 
+    "singlenode": {
+      include "osnailyfacter::cluster_simple"
       class {'os_common':}
       }
-    "multinode": { 
+    "multinode": {
       include osnailyfacter::cluster_simple
       class {'os_common':}
       }

--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -450,8 +450,6 @@ class virtual_ips () {
         debug                => $debug ? { 'true' => true, true => true, default=> false },
         verbose              => $verbose ? { 'true' => true, true => true, default=> false },
         use_syslog           => true,
-        syslog_log_level     => $syslog_log_level,
-        syslog_log_facility  => $syslog_log_facility_cinder,
       }
 #      class { "::rsyslog::client":
 #        log_local => true,

--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -8,7 +8,7 @@ if $quantum == 'true'
 {
   $quantum_hash   = parsejson($::quantum_access)
   $quantum_params = parsejson($::quantum_parameters)
-  $novanetwork_params  = {} 
+  $novanetwork_params  = {}
 
 }
 else
@@ -140,14 +140,14 @@ $network_config = {
 
 
 
-if !$verbose 
+if !$verbose
 {
- $verbose = 'true'
+ $verbose = 'false'
 }
 
 if !$debug
 {
- $debug = 'true'
+ $debug = 'false'
 }
 
 
@@ -173,7 +173,7 @@ $multi_host              = true
 $manage_volumes          = false
 $glance_backend          = 'swift'
 $quantum_netnode_on_cnt  = true
-$swift_loopback = false 
+$swift_loopback = false
 $mirror_type = 'external'
 Exec { logoutput => true }
 
@@ -183,7 +183,7 @@ Exec { logoutput => true }
 class compact_controller (
   $quantum_network_node = $quantum_netnode_on_cnt
 ) {
-   
+
   class {'osnailyfacter::tinyproxy': }
   class { 'openstack::controller_ha':
     controller_public_addresses   => $controller_public_addresses,
@@ -202,8 +202,8 @@ class compact_controller (
     num_networks                  => $num_networks,
     network_size                  => $network_size,
     network_config                => $network_config,
-    verbose                       => $verbose,
-    debug                         => $debug,
+    debug                         => $debug ? { 'true' => true, true => true, default=> false },
+    verbose                       => $verbose ? { 'true' => true, true => true, default=> false },
     queue_provider                => $::queue_provider,
     qpid_password                 => $rabbit_hash[password],
     qpid_user                     => $rabbit_hash[user],
@@ -306,7 +306,10 @@ class virtual_ips () {
         swift_zone            => $swift_zone,
         swift_local_net_ip    => $storage_address,
         master_swift_proxy_ip   => $master_swift_proxy_ip,
-        sync_rings            => ! $primary_proxy
+        sync_rings            => ! $primary_proxy,
+        syslog_log_level      => $syslog_log_level,
+        debug                 => $debug ? { 'true' => true, true => true, default=> false },
+        verbose               => $verbose ? { 'true' => true, true => true, default=> false },
       }
       if $primary_proxy {
         ring_devices {'all': storages => $controllers }
@@ -317,7 +320,10 @@ class virtual_ips () {
         primary_proxy           => $primary_proxy,
         controller_node_address => $management_vip,
         swift_local_net_ip      => $swift_local_net_ip,
-        master_swift_proxy_ip   => $master_swift_proxy_ip
+        master_swift_proxy_ip   => $master_swift_proxy_ip,
+        syslog_log_level        => $syslog_log_level,
+        debug                   => $debug ? { 'true' => true, true => true, default=> false },
+        verbose                 => $verbose ? { 'true' => true, true => true, default=> false },
       }
       #TODO: PUT this configuration stanza into nova class
       nova_config { 'DEFAULT/start_guests_on_host_boot': value => $start_guests_on_host_boot }
@@ -337,7 +343,7 @@ class virtual_ips () {
         Class[openstack::swift::storage_node] -> Class[openstack::img::cirros]
         Class[openstack::swift::proxy]        -> Class[openstack::img::cirros]
         Service[swift-proxy]                  -> Class[openstack::img::cirros]
- 
+
       }
         if !$quantum
         {
@@ -351,7 +357,7 @@ class virtual_ips () {
           auth_url        => "http://${management_vip}:5000/v2.0/",
           authtenant_name => $access_hash[tenant],
         }
-       }	
+       }
 
      }
 
@@ -379,8 +385,8 @@ class virtual_ips () {
         auto_assign_floating_ip => $bool_auto_assign_floating_ip,
         glance_api_servers     => "${management_vip}:9292",
         vncproxy_host          => $public_vip,
-        verbose                => $verbose,
-        debug                  => $debug,
+        debug                  => $debug ? { 'true' => true, true => true, default=> false },
+        verbose                => $verbose ? { 'true' => true, true => true, default=> false },
         cinder_volume_group    => "cinder",
         vnc_enabled            => true,
         manage_volumes         => $cinder ? { false => $manage_volumes, default =>$is_cinder_node },
@@ -400,6 +406,7 @@ class virtual_ips () {
         segment_range          => $segment_range,
         use_syslog             => true,
         syslog_log_level       => $syslog_log_level,
+	syslog_log_facility    => $syslog_log_facility_nova,
         syslog_log_facility_quantum => $syslog_log_facility_quantum,
         syslog_log_facility_cinder => $syslog_log_facility_cinder,
         nova_rate_limits       => $nova_rate_limits,
@@ -440,9 +447,11 @@ class virtual_ips () {
         cinder_user_password => $cinder_hash[user_password],
         syslog_log_facility  => $syslog_log_facility_cinder,
         syslog_log_level     => $syslog_log_level,
-        debug                => $debug ? { 'true' => 'True', default=>'False' },
-        verbose              => $verbose ? { 'false' => 'False', default=>'True' },
+        debug                => $debug ? { 'true' => true, true => true, default=> false },
+        verbose              => $verbose ? { 'true' => true, true => true, default=> false },
         use_syslog           => true,
+        syslog_log_level     => $syslog_log_level,
+        syslog_log_facility  => $syslog_log_facility_cinder,
       }
 #      class { "::rsyslog::client":
 #        log_local => true,

--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha_full.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha_full.pp
@@ -8,7 +8,7 @@ if $quantum == 'true'
 {
   $quantum_hash   = parsejson($::quantum_access)
   $quantum_params = parsejson($::quantum_parameters)
-  $novanetwork_params  = {} 
+  $novanetwork_params  = {}
 }
 else
 {
@@ -62,14 +62,14 @@ if !$rabbit_hash[user]
 $rabbit_user          = $rabbit_hash['user']
 
 
-if !$verbose 
+if !$verbose
 {
- $verbose = 'true'
+ $verbose = 'false'
 }
 
 if !$debug
 {
- $debug = 'true'
+ $debug = 'false'
 }
 
 if !$swift_partition
@@ -211,8 +211,8 @@ class ha_controller (
     num_networks            => $num_networks,
     network_size            => $network_size,
     network_config          => $network_config,
-    verbose                 => $verbose,
-    debug                   => $debug,
+    debug                   => $debug ? { 'true' => true, true => true, default=> false },
+    verbose                 => $verbose ? { 'true' => true, true => true, default=> false },
     auto_assign_floating_ip => $bool_auto_assign_floating_ip,
     mysql_root_password     => $mysql_hash[root_password],
     admin_email             => $access_hash[email],
@@ -335,8 +335,8 @@ case $role {
     qpid_nodes             => [$management_vip],
     glance_api_servers     => "${management_vip}:9292",
     vncproxy_host          => $public_vip,
-    verbose                => $verbose,
-    debug                  => $debug,
+    debug                  => $debug ? { 'true' => true, true => true, default=> false },
+    verbose                => $verbose ? { 'true' => true, true => true, default=> false },
     vnc_enabled            => true,
     nova_user_password     => $nova_hash[user_password],
     cache_server_ip        => $controller_nodes,
@@ -355,6 +355,7 @@ case $role {
     cinder_rate_limits     => $::cinder_rate_limits,
     use_syslog             => $use_syslog,
     syslog_log_level       => $syslog_log_level,
+    syslog_log_facility    => $syslog_log_facility_nova,
     syslog_log_facility_quantum => $syslog_log_facility_quantum,
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
     nova_rate_limits       => $::nova_rate_limits,
@@ -394,7 +395,9 @@ case $role {
     qpid_user              => $rabbit_hash[user],
     qpid_nodes             => [$management_vip],
     sync_rings             => ! $primary_proxy,
-    syslog_log_level => $syslog_log_level,
+    syslog_log_level       => $syslog_log_level,
+    debug                  => $debug ? { 'true' => true, true => true, default=> false },
+    verbose                => $verbose ? { 'true' => true, true => true, default=> false },
     syslog_log_facility_cinder => $syslog_log_facility_cinder,
   }
 
@@ -419,6 +422,9 @@ case $role {
     controller_node_address => $management_vip,
     swift_local_net_ip      => $swift_local_net_ip,
     master_swift_proxy_ip   => $master_swift_proxy_ip,
+    syslog_log_level        => $syslog_log_level,
+    debug                   => $debug ? { 'true' => true, true => true, default=> false },
+    verbose                 => $verbose ? { 'true' => true, true => true, default=> false },
   }
   }
 
@@ -440,8 +446,8 @@ case $role {
         auth_host            => $management_vip,
         iscsi_bind_host      => $storage_address,
         cinder_user_password => $cinder_hash[user_password],
-        debug                => $debug ? { 'true' => 'True', default=>'False' },
-        verbose              => $verbose ? { 'false' => 'False', default=>'True' },
+        debug                => $debug ? { 'true' => true, true => true, default=> false },
+        verbose              => $verbose ? { 'true' => true, true => true, default=> false },
         syslog_log_facility  => $syslog_log_facility_cinder,
         syslog_log_level     => $syslog_log_level,
         use_syslog           => true,

--- a/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
@@ -113,8 +113,6 @@ if !$debug
  $debug = 'true'
 }
 
-
-
   case $role {
     "controller" : {
       include osnailyfacter::test_controller

--- a/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
@@ -5,7 +5,7 @@ if $quantum == 'true'
 {
   $quantum_hash   = parsejson($::quantum_access)
   $quantum_params = parsejson($::quantum_parameters)
-  $novanetwork_params  = {} 
+  $novanetwork_params  = {}
 
 }
 else
@@ -103,14 +103,14 @@ $quantum_sql_connection  = "mysql://${quantum_db_user}:${quantum_db_password}@${
 $quantum_metadata_proxy_shared_secret = $quantum_params['metadata_proxy_shared_secret']
 $quantum_gre_bind_addr = $::internal_address
 
-if !$verbose 
+if !$verbose
 {
- $verbose = 'true'
+ $verbose = 'false'
 }
 
 if !$debug
 {
- $debug = 'true'
+ $debug = 'false'
 }
 
   case $role {
@@ -131,8 +131,8 @@ if !$debug
         num_networks            => $num_networks,
         network_size            => $network_size,
         network_config          => $network_config,
-        verbose                 => $verbose,
-        debug                   => $debug,
+        debug                   => $debug ? { 'true' => true, true => true, default=> false },
+        verbose                 => $verbose ? { 'true' => true, true => true, default=> false },
         auto_assign_floating_ip => $bool_auto_assign_floating_ip,
         mysql_root_password     => $mysql_hash[root_password],
         admin_email             => $access_hash[email],
@@ -192,8 +192,8 @@ if !$debug
       floating_range        => $floating_hash,
       fixed_range           => $fixed_network_range,
       create_networks       => $create_networks,
-      verbose               => $verbose,
-      debug                 => $debug,
+      debug                 => $debug ? { 'true' => true, true => true, default=> false },
+      verbose               => $verbose ? { 'true' => true, true => true, default=> false },
       queue_provider        => $queue_provider,
       rabbit_password       => $rabbit_hash[password],
       rabbit_user           => $rabbit_hash[user],
@@ -302,10 +302,11 @@ if !$debug
         cinder_volume_group     => "cinder",
         manage_volumes          => $cinder ? { false => $manage_volumes, default =>$is_cinder_node },
         db_host                => $controller_node_address,
-        verbose                => $verbose,
-        debug                   => $debug,
+        debug                  => $debug ? { 'true' => true, true => true, default=> false },
+        verbose                => $verbose ? { 'true' => true, true => true, default=> false },
         use_syslog             => true,
         syslog_log_level       => $syslog_log_level,
+	syslog_log_facility    => $syslog_log_facility_nova,
         syslog_log_facility_quantum => $syslog_log_facility_quantum,
         syslog_log_facility_cinder => $syslog_log_facility_cinder,
         state_path             => $nova_hash[state_path],
@@ -340,9 +341,11 @@ if !$debug
         cinder_user_password => $cinder_hash[user_password],
         syslog_log_facility  => $syslog_log_facility_cinder,
         syslog_log_level     => $syslog_log_level,
-        debug                => $debug ? { 'true' => 'True', default=>'False' },
-        verbose              => $verbose ? { 'false' => 'False', default=>'True' },
+        debug                => $debug ? { 'true' => true, true => true, default=> false },
+        verbose              => $verbose ? { 'true' => true, true => true, default=> false },
         use_syslog           => true,
+        syslog_log_level     => $syslog_log_level,
+        syslog_log_facility  => $syslog_log_facility_cinder,
       }
    }
   }

--- a/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
@@ -344,8 +344,6 @@ if !$debug
         debug                => $debug ? { 'true' => true, true => true, default=> false },
         verbose              => $verbose ? { 'true' => true, true => true, default=> false },
         use_syslog           => true,
-        syslog_log_level     => $syslog_log_level,
-        syslog_log_facility  => $syslog_log_facility_cinder,
       }
    }
   }

--- a/deployment/puppet/quantum/files/ocf/quantum-agent-l3
+++ b/deployment/puppet/quantum/files/ocf/quantum-agent-l3
@@ -317,7 +317,9 @@ quantum_l3_agent_start() {
     clean_up
 
     if ocf_is_true ${OCF_RESKEY_syslog} ; then
-        L3_SYSLOG=" | logger -t quantum-quantum.agent.l3 "
+# Disable logger because we use imfile for log files grabbing to rsyslog
+#      L3_SYSLOG=" | logger -t quantum-quantum.agent.l3 "
+        L3_SYSLOG=""
         if ocf_is_true ${OCF_RESKEY_debug} ; then
             L3_LOG=" | tee -ia /var/log/quantum/l3.log "
         else

--- a/deployment/puppet/quantum/files/ocf/quantum-agent-l3
+++ b/deployment/puppet/quantum/files/ocf/quantum-agent-l3
@@ -316,24 +316,25 @@ quantum_l3_agent_start() {
     fi
     clean_up
 
-    if ocf_is_true ${OCF_RESKEY_syslog} ; then
+# FIXME stderr should not be used unless quantum+agents init & OCF would reditect to stderr
+#    if ocf_is_true ${OCF_RESKEY_syslog} ; then
 # Disable logger because we use imfile for log files grabbing to rsyslog
 #      L3_SYSLOG=" | logger -t quantum-quantum.agent.l3 "
-        L3_SYSLOG=""
-        if ocf_is_true ${OCF_RESKEY_debug} ; then
-            L3_LOG=" | tee -ia /var/log/quantum/l3.log "
-        else
-            L3_LOG=" "
-        fi
-    else
-        L3_SYSLOG=""
-        if ocf_is_true ${OCF_RESKEY_debug} ; then
-            L3_LOG=" >> /var/log/quantum/l3.log "
-        else
-            L3_LOG=" >> /dev/null "
-        fi
-    fi
-
+#        if ocf_is_true ${OCF_RESKEY_debug} ; then
+#            L3_LOG=" | tee -ia /var/log/quantum/l3.log "
+#        else
+#            L3_LOG=" "
+#        fi
+#    else
+#        L3_SYSLOG=""
+#        if ocf_is_true ${OCF_RESKEY_debug} ; then
+#            L3_LOG=" >> /var/log/quantum/l3.log "
+#        else
+#            L3_LOG=" >> /dev/null "
+#        fi
+#    fi
+    L3_SYSLOG=""
+    L3_LOG=" > /dev/null "
     # run the actual quantum-l3-agent daemon. Don't use ocf_run as we're sending the tool's output
     # straight to /dev/null anyway and using ocf_run would break stdout-redirection here.
 

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -71,7 +71,7 @@ class quantum (
     owner  => root,
     group  => root,
     source => "puppet:///modules/quantum/q-agent-cleanup.py",
-  } 
+  }
 
   file {'quantum-root':
     path => '/etc/sudoers.d/quantum-root',
@@ -216,7 +216,7 @@ class quantum (
     }
   }
   # We must setup logging before start services under pacemaker
-  File['quantum-logging.conf'] -> Service<| title == 'quantum-server' |>
+  File['quantum-logging.conf'] -> Service<| title == "$::quantum::params::server_service" |>
   File['quantum-logging.conf'] -> Anchor<| title == 'quantum-ovs-agent' |>
   File['quantum-logging.conf'] -> Anchor<| title == 'quantum-l3' |>
   File['quantum-logging.conf'] -> Anchor<| title == 'quantum-dhcp-agent' |>

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -38,6 +38,7 @@ class quantum (
   $auth_tenant      = 'services',
   $auth_user        = 'quantum',
   $log_file               = '/var/log/quantum/server.log',
+  $log_dir          = '/var/log/quantum',
   $use_syslog = false,
   $syslog_log_facility    = 'LOCAL4',
   $syslog_log_level = 'WARNING',
@@ -177,12 +178,12 @@ class quantum (
 
   quantum_config {
       'DEFAULT/log_file':   ensure=> absent;
-      'DEFAULT/log_dir':    ensure=> absent;
       'DEFAULT/logfile':    ensure=> absent;
-      'DEFAULT/logdir':     ensure=> absent;
   }
   if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
     quantum_config {
+        'DEFAULT/log_dir':    ensure=> absent;
+        'DEFAULT/logdir':     ensure=> absent;
         'DEFAULT/log_config':   value => "/etc/quantum/logging.conf";
         'DEFAULT/use_stderr': ensure=> absent;
         'DEFAULT/use_syslog': value=> true;
@@ -204,6 +205,7 @@ class quantum (
       # FIXME stderr should not be used unless quantum+agents init & OCF scripts would be fixed to redirect its output to stderr!
       #'DEFAULT/use_stderr': value => true;
       'DEFAULT/use_stderr': ensure=> absent;
+      'DEFAULT/log_dir': value => $log_dir;
     }
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf-nosyslog.erb'),

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -228,8 +228,16 @@ class quantum (
     $endpoint_quantum_main_configuration = 'quantum-init-done'
   }
 
+  # FIXME remove explicit --log-config from init scripts cuz it breaks logging!
+  exec {'init-dirty-hack':
+    command => "sed -i 's/\-\-log\-config=\$loggingconf//g' /etc/init.d/quantum-*",
+    path    => ["/sbin", "/bin", "/usr/sbin", "/usr/bin"],
+    refreshonly => true,
+  }
+
   Anchor['quantum-init'] ->
     Package['quantum'] ->
+     Exec['init-dirty-hack'] ->
       File['/var/cache/quantum'] ->
         Quantum_config<||> ->
           Quantum_api_config<||> ->

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -1,7 +1,6 @@
 #
 # [use_syslog] Rather or not service should log to syslog. Optional.
-# [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option
-#       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
+# [syslog_log_facility] Facility for syslog, if used. Optional.
 # [syslog_log_level] logging level for non verbose and non debug mode. Optional.
 #
 class quantum (
@@ -166,16 +165,7 @@ class quantum (
     'keystone_authtoken/admin_user':        value => $auth_user;
     'keystone_authtoken/admin_password':    value => $auth_password;
   }
-  # logging for agents grabbing from stderr. It's workarround for bug in quantum-logging
-  # server givs this parameters from command line
-  quantum_config {
-      'DEFAULT/log_config': ensure=> absent;
-      'DEFAULT/log_file':   ensure=> absent;
-      'DEFAULT/log_dir':    ensure=> absent;
-      'DEFAULT/use_syslog': ensure=> absent;
-      'DEFAULT/use_stderr': value => true;
-  }
-  if $use_syslog {
+  if $use_syslog and !$debug =~ /(?i)(true|yes)/ {
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf.erb'),
       path  => "/etc/quantum/logging.conf",
@@ -183,23 +173,27 @@ class quantum (
       group => "quantum",
       mode  => 640,
     }
-
-    # We must setup logging before start services under pacemaker
-    File['quantum-logging.conf'] -> Service<| title == 'quantum-server' |>
-    File['quantum-logging.conf'] -> Anchor<| title == 'quantum-ovs-agent' |>
-    File['quantum-logging.conf'] -> Anchor<| title == 'quantum-l3' |>
-    File['quantum-logging.conf'] -> Anchor<| title == 'quantum-dhcp-agent' |>
-
   } else {
+    quantum_config {
+    # logging for agents grabbing from stderr. It's workarround for bug in quantum-logging
+      'DEFAULT/log_file':   ensure=> absent;
+      'DEFAULT/log_dir':    ensure=> absent;
+      'DEFAULT/use_syslog': ensure=> absent;
+      'DEFAULT/use_stderr': value => true;
+    }
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf-nosyslog.erb'),
       path  => "/etc/quantum/logging.conf",
       owner => "root",
-      group => "root",
-      mode  => 644,
+      group => "quantum",
+      mode  => 640,
     }
   }
-
+  # We must setup logging before start services under pacemaker
+  File['quantum-logging.conf'] -> Service<| title == 'quantum-server' |>
+  File['quantum-logging.conf'] -> Anchor<| title == 'quantum-ovs-agent' |>
+  File['quantum-logging.conf'] -> Anchor<| title == 'quantum-l3' |>
+  File['quantum-logging.conf'] -> Anchor<| title == 'quantum-dhcp-agent' |>
   File <| title=='/etc/quantum' |> -> File <| title=='quantum-logging.conf' |>
 
   if defined(Anchor['quantum-server-config-done']) {

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -201,7 +201,9 @@ class quantum (
       'DEFAULT/use_syslog': ensure=> absent;
       'DEFAULT/syslog_log_facility': ensure=> absent;
       'DEFAULT/log_config': ensure=> absent;
-      'DEFAULT/use_stderr': value => true;
+      # FIXME stderr should not be used unless quantum+agents init & OCF scripts would be fixed to redirect its output to stderr!
+      #'DEFAULT/use_stderr': value => true;
+      'DEFAULT/use_stderr': ensure=> absent;
     }
     file { "quantum-logging.conf":
       content => template('quantum/logging.conf-nosyslog.erb'),

--- a/deployment/puppet/quantum/manifests/init.pp
+++ b/deployment/puppet/quantum/manifests/init.pp
@@ -168,13 +168,13 @@ class quantum (
   }
   # logging for agents grabbing from stderr. It's workarround for bug in quantum-logging
   # server givs this parameters from command line
-  # FIXME change init.d scripts for q&agents for non HA mode, change daemon launch commands (CENTOS/RHEL):
-  # FIXME quantum-server:
-  # FIXME	daemon --user quantum --pidfile $pidfile "$exec --config-file $config --config-file /etc/$prog/plugin.ini &>>/var/log/quantum/server.log & echo \$!
-  # FIXME quantum-ovs-cleanup:
-  # FIXME	daemon --user quantum $exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log
+  # FIXME change init.d scripts for q&agents, fix daemon launch commands (CENTOS/RHEL):
+  # quantum-server:
+  #	daemon --user quantum --pidfile $pidfile "$exec --config-file $config --config-file /etc/$prog/plugin.ini &>>/var/log/quantum/server.log & echo \$!
+  # quantum-ovs-cleanup:
+  # 	daemon --user quantum $exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log
   # quantum-ovs/metadata/l3/dhcp/-agents:
-  # FIXME	daemon --user quantum --pidfile $pidfile "$exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log & echo \$! > $pidfile"
+  # 	daemon --user quantum --pidfile $pidfile "$exec --config-file /etc/$proj/$proj.conf --config-file $config &>>/var/log/$proj/$plugin.log & echo \$! > $pidfile"
 
   quantum_config {
       'DEFAULT/log_file':   ensure=> absent;
@@ -228,11 +228,11 @@ class quantum (
     $endpoint_quantum_main_configuration = 'quantum-init-done'
   }
 
-  # FIXME remove explicit --log-config from init scripts cuz it breaks logging!
+  # FIXME Workaround for FUEL-842: remove explicit --log-config from init scripts cuz it breaks logging!
+  # FIXME this hack should be deleted after FUEL-842 have resolved
   exec {'init-dirty-hack':
     command => "sed -i 's/\-\-log\-config=\$loggingconf//g' /etc/init.d/quantum-*",
     path    => ["/sbin", "/bin", "/usr/sbin", "/usr/bin"],
-    refreshonly => true,
   }
 
   Anchor['quantum-init'] ->

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -22,10 +22,10 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = quantum-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
+format = quantum-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = quantum-%(name)s %(levelname)s %(message)s
+format = quantum-%(name)s %(levelname)s: %(message)s
 
 [formatter_default]
 format=%(asctime)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -1,11 +1,20 @@
+<% if @debug then -%>
+[loggers]
+keys = root, l3agent, ovsagent, dhcpagent, metadata
+
+[handlers]
+keys = production,devel,stderr, l3agent, ovsagent, dhcpagent, metadata
+
+<% else -%>
 [loggers]
 keys = root
 
 [handlers]
 keys = production,devel,stderr
 
+<% end -%>
 [formatters]
-keys = normal,debug
+keys = normal,debug,default
 
 [logger_root]
 level = NOTSET
@@ -13,16 +22,15 @@ handlers = production,devel,stderr
 propagate = 1
 
 [formatter_debug]
-format = quantum-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
+format = quantum-%(name)s %(levelname)s %(module)s %(funcName)s %(message)s
 
 [formatter_normal]
-format = quantum-%(name)s %(levelname)s: %(module)s %(message)s
+format = quantum-%(name)s %(levelname)s %(message)s
 
 [formatter_default]
 format=%(asctime)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s
 
-# Extended logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
-# Note: local copy goes to /var/log/quantum-all.log
+# logging info to LOG_<%= @syslog_log_facility %> with debug:<%= @debug %> and verbose:<%= @verbose %>
 [handler_production]
 class = handlers.SysLogHandler
 <% if @debug then -%>
@@ -65,3 +73,48 @@ level = <%= @syslog_log_level %>
 formatter = normal
 <% end -%>
 args = (sys.stdout,)
+
+<% if @debug then -%>
+[logger_l3agent]
+handlers = l3agent
+level=NOTSET
+qualname = quantum.agent.l3_agent
+
+[handler_l3agent]
+class = logging.FileHandler
+args = ('/var/log/quantum/l3.log',)
+formatter = default
+
+
+[logger_dhcpagent]
+handlers = dhcpagent
+level=NOTSET
+qualname = quantum.agent.dhcp_agent
+
+[handler_dhcpagent]
+class = logging.FileHandler
+args = ('/var/log/quantum/dhcp.log',)
+formatter = default
+
+
+[logger_ovsagent]
+handlers = ovsagent
+level=NOTSET
+qualname = quantum.plugins.openvswitch.agent.ovs_quantum_agent
+
+[handler_ovsagent]
+class = logging.FileHandler
+args = ('/var/log/quantum/ovs.log',)
+formatter = default
+
+
+[logger_metadata]
+handlers = metadata
+level=NOTSET
+qualname = quantum.agent.metadata
+
+[handler_metadata]
+class = logging.FileHandler
+args = ('/var/log/quantum/metadata.log',)
+formatter = default
+<% end -%>

--- a/deployment/puppet/quantum/templates/logging.conf.erb
+++ b/deployment/puppet/quantum/templates/logging.conf.erb
@@ -1,34 +1,22 @@
-<% if @debug then -%>
-[loggers]
-keys = root, l3agent, ovsagent, dhcpagent, metadata
-
-[handlers]
-keys = production,devel, l3agent, ovsagent, dhcpagent, metadata
-
-<% else -%>
 [loggers]
 keys = root
 
-# devel is reserved for future usage
 [handlers]
-keys = production,devel
+keys = production,devel,stderr
 
-<% end -%>
+[formatters]
+keys = normal,debug
 
 [logger_root]
 level = NOTSET
-handlers = production
+handlers = production,devel,stderr
 propagate = 1
-#qualname = quantum
-
-[formatters]
-keys = normal,debug,default
 
 [formatter_debug]
-format = quantum-%(name)s %(levelname)s: %(module)s %(funcName)s %(message)s
+format = quantum-%(name)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s %(message)s
 
 [formatter_normal]
-format = quantum-%(name)s %(levelname)s: %(message)s
+format = quantum-%(name)s %(levelname)s: %(module)s %(message)s
 
 [formatter_default]
 format=%(asctime)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s  %(message)s
@@ -39,61 +27,41 @@ format=%(asctime)s %(levelname)s: %(module)s %(name)s:%(lineno)d %(funcName)s  %
 class = handlers.SysLogHandler
 <% if @debug then -%>
 level = DEBUG
+formatter = debug
 <% elsif @verbose then -%>
 level = INFO
+formatter = normal
 <% else -%>
 level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
 args = ('/dev/log', handlers.SysLogHandler.LOG_<%= @syslog_log_facility %>)
-formatter = normal
 
 # TODO find out how it could be usefull and how it should be used
+[handler_stderr]
+class = StreamHandler
+<% if @debug then -%>
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
+<% end -%>
+args = (sys.stderr,)
+
 [handler_devel]
 class = StreamHandler
-formatter = debug
-args = (sys.stdout,)
-
 <% if @debug then -%>
-[logger_l3agent]
-handlers = l3agent
-level=NOTSET
-qualname = quantum.agent.l3_agent
-
-[handler_l3agent]
-class = logging.FileHandler
-args = ('/var/log/quantum/l3.log',)
-formatter = default
-
-
-[logger_dhcpagent]
-handlers = dhcpagent
-level=NOTSET
-qualname = quantum.agent.dhcp_agent
-
-[handler_dhcpagent]
-class = logging.FileHandler
-args = ('/var/log/quantum/dhcp.log',)
-formatter = default
-
-
-[logger_ovsagent]
-handlers = ovsagent
-level=NOTSET
-qualname = quantum.plugins.openvswitch.agent.ovs_quantum_agent
-
-[handler_ovsagent]
-class = logging.FileHandler
-args = ('/var/log/quantum/ovs.log',)
-formatter = default
-
-
-[logger_metadata]
-handlers = metadata
-level=NOTSET
-qualname = quantum.agent.metadata
-
-[handler_metadata]
-class = logging.FileHandler
-args = ('/var/log/quantum/metadata.log',)
-formatter = default
+level = DEBUG
+formatter = debug
+<% elsif @verbose then -%>
+level = INFO
+formatter = normal
+<% else -%>
+level = <%= @syslog_log_level %>
+formatter = normal
 <% end -%>
+args = (sys.stdout,)

--- a/deployment/puppet/rsyslog/manifests/client.pp
+++ b/deployment/puppet/rsyslog/manifests/client.pp
@@ -195,28 +195,28 @@ if $::debug =~ /(?i)(true|yes)/ {
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-ovs-agent_debug" :
-    file_name     => "/var/log/quantum/ovs-agent.log",
+    file_name     => "/var/log/quantum/ovs.log",
     file_tag      => "quantum-ovs-agent",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-l3-agent_debug" :
-    file_name     => "/var/log/quantum/l3-agent.log",
+    file_name     => "/var/log/quantum/l3.log",
     file_tag      => "quantum-l3-agent",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-dhcp-agent_debug" :
-    file_name     => "/var/log/quantum/dhcp-agent.log",
+    file_name     => "/var/log/quantum/dhcp.log",
     file_tag      => "quantum-dhcp-agent",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-metadata-agent_debug" :
-    file_name     => "/var/log/quantum/metadata-agent.log",
+    file_name     => "/var/log/quantum/metadata.log",
     file_tag      => "quantum-metadata-agent",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",

--- a/deployment/puppet/rsyslog/manifests/client.pp
+++ b/deployment/puppet/rsyslog/manifests/client.pp
@@ -194,34 +194,72 @@ if $::debug =~ /(?i)(true|yes)/ {
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
+::rsyslog::imfile { "50-quantum-rescheduling_debug" :
+   file_name     => "/var/log/quantum/rescheduling.log",
+   file_tag      => "quantum-rescheduling",
+   file_facility => $::syslog_log_facility_quantum,
+   file_severity => "DEBUG",
+   notify  => Class["rsyslog::service"],
+}
 ::rsyslog::imfile { "50-quantum-ovs-agent_debug" :
-    file_name     => "/var/log/quantum/ovs.log",
-    file_tag      => "quantum-ovs-agent",
+    file_name     => "/var/log/quantum/openvswitch-agent.log",
+    file_tag      => "quantum-agent-ovs",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-l3-agent_debug" :
-    file_name     => "/var/log/quantum/l3.log",
-    file_tag      => "quantum-l3-agent",
+    file_name     => "/var/log/quantum/l3-agent.log",
+    file_tag      => "quantum-agent-l3",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-dhcp-agent_debug" :
-    file_name     => "/var/log/quantum/dhcp.log",
-    file_tag      => "quantum-dhcp-agent",
+    file_name     => "/var/log/quantum/dhcp-agent.log",
+    file_tag      => "quantum-agent-dhcp",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-metadata-agent_debug" :
-    file_name     => "/var/log/quantum/metadata.log",
-    file_tag      => "quantum-metadata-agent",
+    file_name     => "/var/log/quantum/metadata-agent.log",
+    file_tag      => "quantum-agent-metadata",
     file_facility => $::syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
+# FIXME Workaround for FUEL-843 (HA any)
+# FIXME remove after FUEL-843 have reolved
+::rsyslog::imfile { "50-ha-quantum-ovs-agent_debug" :
+    file_name     => "/var/log/quantum/quantum-openvswitch-agent.log",
+    file_tag      => "quantum-agent-ovs",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-ha-quantum-l3-agent_debug" :
+    file_name     => "/var/log/quantum/quantum-l3-agent.log",
+    file_tag      => "quantum-agent-l3",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-ha-quantum-dhcp-agent_debug" :
+    file_name     => "/var/log/quantum/quantum-dhcp-agent.log",
+    file_tag      => "quantum-agent-dhcp",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-ha-quantum-metadata-agent_debug" :
+    file_name     => "/var/log/quantum/quantum-metadata-agent.log",
+    file_tag      => "quantum-agent-metadata",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+# END fixme
 } else { #non debug case
 # standard logging configs for syslog client
   file { "${rsyslog::params::rsyslog_d}10-nova.conf":

--- a/deployment/puppet/rsyslog/manifests/client.pp
+++ b/deployment/puppet/rsyslog/manifests/client.pp
@@ -20,6 +20,7 @@ class rsyslog::client (
   $syslog_log_facility_nova     = 'LOCAL6',
   $syslog_log_facility_keystone = 'LOCAL7',
   $log_level      = 'NOTICE',
+  $debug          = false,
   ) inherits rsyslog {
 
 # Fix for udp checksums should be applied if running on virtual node
@@ -81,151 +82,151 @@ if $virtual { include rsyslog::checksum_udp514 }
 
 # openstack syslog compatible mode, would work only for debug case.
 # because of its poor syslog debug messages quality, use local logs convertion
-if $::debug =~ /(?i)(true|yes)/ {
+if $debug =~ /(?i)(true|yes)/ {
 ::rsyslog::imfile { "10-nova-api_debug" :
     file_name     => "/var/log/nova/api.log",
     file_tag      => "nova-api",
-    file_facility => $::syslog_log_facility_nova,
+    file_facility => $syslog_log_facility_nova,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "10-nova-cert_debug" :
     file_name     => "/var/log/nova/cert.log",
     file_tag      => "nova-cert",
-    file_facility => $::syslog_log_facility_nova,
+    file_facility => $syslog_log_facility_nova,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "10-nova-consoleauth_debug" :
     file_name     => "/var/log/nova/consoleauth.log",
     file_tag      => "nova-consoleauth",
-    file_facility => $::syslog_log_facility_nova,
+    file_facility => $syslog_log_facility_nova,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "10-nova-scheduler_debug" :
     file_name     => "/var/log/nova/scheduler.log",
     file_tag      => "nova-scheduler",
-    file_facility => $::syslog_log_facility_nova,
+    file_facility => $syslog_log_facility_nova,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "10-nova-network_debug" :
     file_name     => "/var/log/nova/network.log",
     file_tag      => "nova-network",
-    file_facility => $::syslog_log_facility_nova,
+    file_facility => $syslog_log_facility_nova,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "10-nova-compute_debug" :
     file_name     => "/var/log/nova/compute.log",
     file_tag      => "nova-compute",
-    file_facility => $::syslog_log_facility_nova,
+    file_facility => $syslog_log_facility_nova,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "10-nova-conductor_debug" :
     file_name     => "/var/log/nova/conductor.log",
     file_tag      => "nova-conductor",
-    file_facility => $::syslog_log_facility_nova,
+    file_facility => $syslog_log_facility_nova,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "10-nova-objectstore_debug" :
     file_name     => "/var/log/nova/objectstore.log",
     file_tag      => "nova-objectstore",
-    file_facility => $::syslog_log_facility_nova,
+    file_facility => $syslog_log_facility_nova,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "20-keystone_debug" :
     file_name     => "/var/log/keystone/keystone.log",
     file_tag      => "keystone",
-    file_facility => $::syslog_log_facility_keystone,
+    file_facility => $syslog_log_facility_keystone,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "30-cinder-api_debug" :
     file_name     => "/var/log/cinder/api.log",
     file_tag      => "cinder-api",
-    file_facility => $::syslog_log_facility_cinder,
+    file_facility => $syslog_log_facility_cinder,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "30-cinder-volume_debug" :
     file_name     => "/var/log/cinder/volume.log",
     file_tag      => "cinder-volume",
-    file_facility => $::syslog_log_facility_cinder,
+    file_facility => $syslog_log_facility_cinder,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "30-cinder-scheduler_debug" :
     file_name     => "/var/log/cinder/scheduler.log",
     file_tag      => "cinder-scheduler",
-    file_facility => $::syslog_log_facility_cinder,
+    file_facility => $syslog_log_facility_cinder,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "40-glance-api_debug" :
     file_name     => "/var/log/glance/api.log",
     file_tag      => "glance-api",
-    file_facility => $::syslog_log_facility_glance,
+    file_facility => $syslog_log_facility_glance,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "40-glance-registry_debug" :
     file_name     => "/var/log/glance/registry.log",
     file_tag      => "glance-registry",
-    file_facility => $::syslog_log_facility_glance,
+    file_facility => $syslog_log_facility_glance,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-server_debug" :
     file_name     => "/var/log/quantum/server.log",
     file_tag      => "quantum-server",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-ovs-cleanup_debug" :
     file_name     => "/var/log/quantum/ovs-cleanup.log",
     file_tag      => "quantum-ovs-cleanup",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-rescheduling_debug" :
    file_name     => "/var/log/quantum/rescheduling.log",
    file_tag      => "quantum-rescheduling",
-   file_facility => $::syslog_log_facility_quantum,
+   file_facility => $syslog_log_facility_quantum,
    file_severity => "DEBUG",
    notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-ovs-agent_debug" :
     file_name     => "/var/log/quantum/openvswitch-agent.log",
     file_tag      => "quantum-agent-ovs",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-l3-agent_debug" :
     file_name     => "/var/log/quantum/l3-agent.log",
     file_tag      => "quantum-agent-l3",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-dhcp-agent_debug" :
     file_name     => "/var/log/quantum/dhcp-agent.log",
     file_tag      => "quantum-agent-dhcp",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-quantum-metadata-agent_debug" :
     file_name     => "/var/log/quantum/metadata-agent.log",
     file_tag      => "quantum-agent-metadata",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
@@ -234,28 +235,28 @@ if $::debug =~ /(?i)(true|yes)/ {
 ::rsyslog::imfile { "50-ha-quantum-ovs-agent_debug" :
     file_name     => "/var/log/quantum/quantum-openvswitch-agent.log",
     file_tag      => "quantum-agent-ovs",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-ha-quantum-l3-agent_debug" :
     file_name     => "/var/log/quantum/quantum-l3-agent.log",
     file_tag      => "quantum-agent-l3",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-ha-quantum-dhcp-agent_debug" :
     file_name     => "/var/log/quantum/quantum-dhcp-agent.log",
     file_tag      => "quantum-agent-dhcp",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }
 ::rsyslog::imfile { "50-ha-quantum-metadata-agent_debug" :
     file_name     => "/var/log/quantum/quantum-metadata-agent.log",
     file_tag      => "quantum-agent-metadata",
-    file_facility => $::syslog_log_facility_quantum,
+    file_facility => $syslog_log_facility_quantum,
     file_severity => "DEBUG",
     notify  => Class["rsyslog::service"],
 }

--- a/deployment/puppet/rsyslog/manifests/client.pp
+++ b/deployment/puppet/rsyslog/manifests/client.pp
@@ -79,16 +79,151 @@ if $virtual { include rsyslog::checksum_udp514 }
     notify  => Class["rsyslog::service"],
   }
 
-  file { "${rsyslog::params::rsyslog_d}02-ha.conf":
-    ensure => present,
-    content => template("${module_name}/02-ha.conf.erb"),
-  }
-
-  file { "${rsyslog::params::rsyslog_d}03-dashboard.conf":
-    ensure => present,
-    content => template("${module_name}/03-dashboard.conf.erb"),
-  }
-
+# openstack syslog compatible mode, would work only for debug case.
+# because of its poor syslog debug messages quality, use local logs convertion
+if $::debug =~ /(?i)(true|yes)/ {
+::rsyslog::imfile { "10-nova-api_debug" :
+    file_name     => "/var/log/nova/api.log",
+    file_tag      => "nova-api",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-cert_debug" :
+    file_name     => "/var/log/nova/cert.log",
+    file_tag      => "nova-cert",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-consoleauth_debug" :
+    file_name     => "/var/log/nova/consoleauth.log",
+    file_tag      => "nova-consoleauth",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-scheduler_debug" :
+    file_name     => "/var/log/nova/scheduler.log",
+    file_tag      => "nova-scheduler",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-network_debug" :
+    file_name     => "/var/log/nova/network.log",
+    file_tag      => "nova-network",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-compute_debug" :
+    file_name     => "/var/log/nova/compute.log",
+    file_tag      => "nova-compute",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-conductor_debug" :
+    file_name     => "/var/log/nova/conductor.log",
+    file_tag      => "nova-conductor",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "10-nova-objectstore_debug" :
+    file_name     => "/var/log/nova/objectstore.log",
+    file_tag      => "nova-objectstore",
+    file_facility => $::syslog_log_facility_nova,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "20-keystone_debug" :
+    file_name     => "/var/log/keystone/keystone.log",
+    file_tag      => "keystone",
+    file_facility => $::syslog_log_facility_keystone,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "30-cinder-api_debug" :
+    file_name     => "/var/log/cinder/api.log",
+    file_tag      => "cinder-api",
+    file_facility => $::syslog_log_facility_cinder,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "30-cinder-volume_debug" :
+    file_name     => "/var/log/cinder/volume.log",
+    file_tag      => "cinder-volume",
+    file_facility => $::syslog_log_facility_cinder,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "30-cinder-scheduler_debug" :
+    file_name     => "/var/log/cinder/scheduler.log",
+    file_tag      => "cinder-scheduler",
+    file_facility => $::syslog_log_facility_cinder,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "40-glance-api_debug" :
+    file_name     => "/var/log/glance/api.log",
+    file_tag      => "glance-api",
+    file_facility => $::syslog_log_facility_glance,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "40-glance-registry_debug" :
+    file_name     => "/var/log/glance/registry.log",
+    file_tag      => "glance-registry",
+    file_facility => $::syslog_log_facility_glance,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-server_debug" :
+    file_name     => "/var/log/quantum/server.log",
+    file_tag      => "quantum-server",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-ovs-cleanup_debug" :
+    file_name     => "/var/log/quantum/ovs-cleanup.log",
+    file_tag      => "quantum-ovs-cleanup",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-ovs-agent_debug" :
+    file_name     => "/var/log/quantum/ovs-agent.log",
+    file_tag      => "quantum-ovs-agent",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-l3-agent_debug" :
+    file_name     => "/var/log/quantum/l3-agent.log",
+    file_tag      => "quantum-l3-agent",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-dhcp-agent_debug" :
+    file_name     => "/var/log/quantum/dhcp-agent.log",
+    file_tag      => "quantum-dhcp-agent",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+::rsyslog::imfile { "50-quantum-metadata-agent_debug" :
+    file_name     => "/var/log/quantum/metadata-agent.log",
+    file_tag      => "quantum-metadata-agent",
+    file_facility => $::syslog_log_facility_quantum,
+    file_severity => "DEBUG",
+    notify  => Class["rsyslog::service"],
+}
+} else { #non debug case
+# standard logging configs for syslog client
   file { "${rsyslog::params::rsyslog_d}10-nova.conf":
     ensure => present,
     content => template("${module_name}/10-nova.conf.erb"),
@@ -113,6 +248,18 @@ if $virtual { include rsyslog::checksum_udp514 }
     ensure => present,
     content => template("${module_name}/50-quantum.conf.erb"),
   }
+} #end if
+
+  file { "${rsyslog::params::rsyslog_d}02-ha.conf":
+    ensure => present,
+    content => template("${module_name}/02-ha.conf.erb"),
+  }
+
+  file { "${rsyslog::params::rsyslog_d}03-dashboard.conf":
+    ensure => present,
+    content => template("${module_name}/03-dashboard.conf.erb"),
+  }
+
 
   file { "${rsyslog::params::rsyslog_d}60-puppet-agent.conf":
     content => template("${module_name}/60-puppet-agent.conf.erb"),

--- a/deployment/puppet/rsyslog/templates/00-remote.conf.erb
+++ b/deployment/puppet/rsyslog/templates/00-remote.conf.erb
@@ -3,13 +3,10 @@
 <% if scope.lookupvar('rsyslog::client::log_remote') -%>
 # Log to remote syslog server using <%= scope.lookupvar('rsyslog::client::remote_type') %>
 # Templates
-<% if scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-# Use high precision timestamps (date-rfc3339, 2010-12-05T02:21:41.889482+01:00)
-$Template RemoteLog, "<%%PRI%>%TIMEGENERATED:1:32:date-rfc3339% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%\n"
-<% else -%>
-# Use traditional timestamps (date-rfc3164, Dec 5 02:21:13)
-$Template RemoteLog, "<%%PRI%>%TIMEGENERATED:1:15:date-rfc3164% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%\n"
-<% end -%>
+# RFC3164 emulation with long tags (32+)
+$Template RemoteLog, "<%%pri%>%timestamp% %hostname% %syslogtag%%msg:::sp-if-no-1st-sp%%msg%\n"
+# RFC5424 emulation would be: "<%%pri%>1 %timestamp:::date-rfc3339% %hostname% %syslogtag% %procid% %msgid% %structured-data% %msg%\n"
+# Note: don't use %app-name% cuz it would be empty for some cases
 $ActionFileDefaultTemplate RemoteLog
 
 <% scope.lookupvar('rsyslog::client::rservers_real').each do |rserver| -%>

--- a/deployment/puppet/rsyslog/templates/00-server.conf.erb
+++ b/deployment/puppet/rsyslog/templates/00-server.conf.erb
@@ -20,7 +20,6 @@ $EscapeControlCharactersOnReceive off
 # Disk-Assisted Memory Queues, async writes, no escape chars
 #
 $OMFileASyncWriting on
-$SystemLogRateLimitInterval 0   # disable rate limits for rsyslog
 $MainMsgQueueType LinkedList
 $WorkDirectory <%= scope.lookupvar('rsyslog::params::spool_dir') %>
 $MainMsgQueueFileName mainmsgqueue

--- a/deployment/puppet/rsyslog/templates/01-client.conf.erb
+++ b/deployment/puppet/rsyslog/templates/01-client.conf.erb
@@ -8,7 +8,6 @@ $EscapeControlCharactersOnReceive off
 # Disk-Assisted Memory Queues, async writes, no escape chars
 #
 $OMFileASyncWriting on
-$SystemLogRateLimitInterval 0   # disable rate limits for rsyslog
 $MainMsgQueueType LinkedList
 $WorkDirectory <%= scope.lookupvar('rsyslog::params::spool_dir') %>
 $MainMsgQueueFileName mainmsgqueue

--- a/deployment/puppet/rsyslog/templates/02-ha.conf.erb
+++ b/deployment/puppet/rsyslog/templates/02-ha.conf.erb
@@ -1,11 +1,4 @@
 # managed by puppet
-<% unless scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 LOCAL0.* -/var/log/ha.log
 LOCAL0.* ~

--- a/deployment/puppet/rsyslog/templates/03-dashboard.conf.erb
+++ b/deployment/puppet/rsyslog/templates/03-dashboard.conf.erb
@@ -1,11 +1,4 @@
 # managed by puppet
-<% unless scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 LOCAL1.* -/var/log/dashboard.log
 LOCAL1.* ~

--- a/deployment/puppet/rsyslog/templates/10-nova.conf.erb
+++ b/deployment/puppet/rsyslog/templates/10-nova.conf.erb
@@ -1,11 +1,4 @@
 # managed by puppet
-<% unless scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 <%= @syslog_log_facility_nova %>.* -/var/log/nova-all.log
 <%= @syslog_log_facility_nova %>.* ~

--- a/deployment/puppet/rsyslog/templates/20-keystone.conf.erb
+++ b/deployment/puppet/rsyslog/templates/20-keystone.conf.erb
@@ -1,11 +1,4 @@
 # managed by puppet
-<% unless scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 <%= @syslog_log_facility_keystone %>.* -/var/log/keystone-all.log
 <%= @syslog_log_facility_keystone %>.* ~

--- a/deployment/puppet/rsyslog/templates/30-cinder.conf.erb
+++ b/deployment/puppet/rsyslog/templates/30-cinder.conf.erb
@@ -1,11 +1,4 @@
 # managed by puppet
-<% unless scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 <%= @syslog_log_facility_cinder %>.* -/var/log/cinder-all.log
 <%= @syslog_log_facility_cinder %>.* ~

--- a/deployment/puppet/rsyslog/templates/40-glance.conf.erb
+++ b/deployment/puppet/rsyslog/templates/40-glance.conf.erb
@@ -1,11 +1,4 @@
 # managed by puppet
-<% unless scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 <%= @syslog_log_facility_glance %>.* -/var/log/glance-all.log
 <%= @syslog_log_facility_glance %>.* ~

--- a/deployment/puppet/rsyslog/templates/50-quantum.conf.erb
+++ b/deployment/puppet/rsyslog/templates/50-quantum.conf.erb
@@ -1,11 +1,4 @@
 # managed by puppet
-<% unless scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 <%= @syslog_log_facility_quantum %>.* -/var/log/quantum-all.log
 <%= @syslog_log_facility_quantum %>.* ~

--- a/deployment/puppet/rsyslog/templates/60-puppet-agent.conf.erb
+++ b/deployment/puppet/rsyslog/templates/60-puppet-agent.conf.erb
@@ -1,10 +1,3 @@
 # file is managed by puppet
-<% unless @high_precision_timestamps -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 if $programname == 'puppet-agent' then /var/log/puppet/agent.log

--- a/deployment/puppet/rsyslog/templates/90-local.conf.erb
+++ b/deployment/puppet/rsyslog/templates/90-local.conf.erb
@@ -1,12 +1,5 @@
 # file is managed by puppet
 #
-<% unless scope.lookupvar('rsyslog::client::high_precision_timestamps') -%>
-#
-# Use traditional timestamp format date-rfc3164 (Dec 5 02:21:13).
-# To enable high precision timestamps date-rfc3339 (2010-12-05T02:21:41.889482+01:00), comment out the following line.
-#
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% end -%>
 
 <% if scope.lookupvar('rsyslog::client::log_auth_local') or scope.lookupvar('rsyslog::client::log_local') -%>
 # Log auth messages locally

--- a/deployment/puppet/swift/manifests/proxy.pp
+++ b/deployment/puppet/swift/manifests/proxy.pp
@@ -45,7 +45,10 @@ class swift::proxy(
   $workers = $::processorcount,
   $allow_account_management = true,
   $account_autocreate = true,
-  $package_ensure = 'present'
+  $package_ensure = 'present',
+  $debug = false,
+  $verbose = true,
+  $syslog_log_level = 'WARNING',
 ) {
 
   include 'swift::params'

--- a/deployment/puppet/swift/manifests/storage/all.pp
+++ b/deployment/puppet/swift/manifests/storage/all.pp
@@ -27,6 +27,9 @@ class swift::storage::all(
   $container_pipeline = undef,
   $account_pipeline   = undef,
   $export_devices     = false,
+  $debug              = false,
+  $verbose            = true,
+  $syslog_log_level   = 'WARNING',
 ) {
 
   class { 'swift::storage':
@@ -69,6 +72,9 @@ class swift::storage::all(
     swift_zone           => $swift_zone,
     devices              => $devices,
     storage_local_net_ip => $storage_local_net_ip,
+    debug                => $debug,
+    verbose              => $verbose,
+    syslog_log_level     => $syslog_log_level,
   }
 
   swift::storage::server { $account_port:

--- a/deployment/puppet/swift/manifests/storage/server.pp
+++ b/deployment/puppet/swift/manifests/storage/server.pp
@@ -20,7 +20,10 @@ define swift::storage::server(
   $updater_concurrency    = $::processorcount,
   $reaper_concurrency     = $::processorcount,
   # this parameters needs to be specified after type and name
-  $config_file_path       = "${type}-server/${name}.conf"
+  $config_file_path       = "${type}-server/${name}.conf",
+  $debug                  = false,
+  $verbose                = true,
+  $syslog_log_level       = 'WARNING',
 ) {
   if (is_array($pipeline)) {
     $pipeline_real = $pipeline

--- a/deployment/puppet/swift/templates/account-server.conf.erb
+++ b/deployment/puppet/swift/templates/account-server.conf.erb
@@ -5,12 +5,12 @@ bind_port = <%= bind_port %>
 mount_check = <%= mount_check %>
 user = <%= user %>
 log_facility = LOG_SYSLOG
-<% if scope.lookupvar('::debug') then -%>
+<% if @debug then -%>
 log_level = DEBUG
-<% elsif scope.lookupvar('::verbose') then -%>
+<% elsif @verbose then -%>
 log_level = INFO
 <% else -%>
-log_level = <%= scope.lookupvar('::syslog_log_level') %>
+log_level = <%= @syslog_log_level %>
 <% end -%>
 log_name = swift-account-server
 workers = <%= workers %>

--- a/deployment/puppet/swift/templates/container-server.conf.erb
+++ b/deployment/puppet/swift/templates/container-server.conf.erb
@@ -5,12 +5,12 @@ bind_port = <%= bind_port %>
 mount_check = <%= mount_check %>
 user = <%= user %>
 log_facility = LOG_SYSLOG
-<% if scope.lookupvar('::debug') then -%>
+<% if @debug then -%>
 log_level = DEBUG
-<% elsif scope.lookupvar('::verbose') then -%>
+<% elsif @verbose then -%>
 log_level = INFO
 <% else -%>
-log_level = <%= scope.lookupvar('::syslog_log_level') %>
+log_level = <%= @syslog_log_level %>
 <% end -%>
 log_name = swift-container-server
 workers = <%= workers %>

--- a/deployment/puppet/swift/templates/object-server.conf.erb
+++ b/deployment/puppet/swift/templates/object-server.conf.erb
@@ -5,12 +5,12 @@ bind_port = <%= bind_port %>
 mount_check = <%= mount_check %>
 user = <%= user %>
 log_facility = LOG_SYSLOG
-<% if scope.lookupvar('::debug') then -%>
+<% if @debug then -%>
 log_level = DEBUG
-<% elsif scope.lookupvar('::verbose') then -%>
+<% elsif @verbose then -%>
 log_level = INFO
 <% else -%>
-log_level = <%= scope.lookupvar('::syslog_log_level') %>
+log_level = <%= @syslog_log_level %>
 <% end -%>
 log_name = swift-object-server
 workers = <%= workers %>

--- a/deployment/puppet/swift/templates/proxy-server.conf.erb
+++ b/deployment/puppet/swift/templates/proxy-server.conf.erb
@@ -5,12 +5,12 @@ bind_ip = <%= proxy_local_net_ip %>
 bind_port = <%= port %>
 workers = <%= workers %>
 log_facility = LOG_SYSLOG
-<% if scope.lookupvar('::debug') then -%>
+<% if @debug then -%>
 log_level = DEBUG
-<% elsif scope.lookupvar('::verbose') then -%>
+<% elsif @verbose then -%>
 log_level = INFO
 <% else -%>
-log_level = <%= scope.lookupvar('::syslog_log_level') %>
+log_level = <%= @syslog_log_level %>
 <% end -%>
 log_name = swift-proxy-server
 user = swift

--- a/iso/bootstrap_admin_node.sh
+++ b/iso/bootstrap_admin_node.sh
@@ -38,7 +38,7 @@ puppet apply -e "
       limitsize      => '100M',
       port           => '514',
       proto          => 'udp',
-      show_timezone  => false,
+      show_timezone  => true,
      #virtual        => false,
     }"
 puppet apply -e "

--- a/iso/bootstrap_admin_node.sh
+++ b/iso/bootstrap_admin_node.sh
@@ -32,13 +32,13 @@ puppet apply -e "
       log_remote     => false,
       log_local      => true,
       log_auth_local => true,
-      rotation       => 'daily',
-      keep           => '7',
+      rotation       => 'weekly',
+      keep           => '4',
       # should be > 30M
       limitsize      => '100M',
       port           => '514',
       proto          => 'udp',
-      show_timezone  => true,
+      show_timezone  => false,
      #virtual        => false,
     }"
 puppet apply -e "


### PR DESCRIPTION
Implements option 2 for 835 suggested solutions
WA for FUEL-842, FUEL-843
- StdErr must not be used unless all quantum+agents init & ocf scripts would redirect its stderr to logfiles (&>>/var/log/foo/bar.log)
- Thus, undo powerfull debug via stderr - #373
- Remove use_stderr, use logdir options for stdout instead
- Dirty hack for quantum init script to remove all its --log-config from daemon, cuz it breaks logging
- Use rsyslog::imfile monitoring features for local openstack logfiles for syslog + debug case
- Fix imfile templates for quantum debug to use normalized syslogtags
- Get rid of top scoped global vars references (for logging features)
- Add /var/log/{syslog,corosync} to rotation plans
- Fix verbose/debug logic for cluster_*, examples, and site.pp
- High timestamps date-rfc3339 as default
- Weekly rotate & keep rotated logs for 4 weeks at master node as default (was daily, keep 7)
