### PR TITLE
persisitent reconnect to database was added

### DIFF
--- a/deployment/puppet/cobbler/templates/snippets/ubuntu_puppet_config.erb
+++ b/deployment/puppet/cobbler/templates/snippets/ubuntu_puppet_config.erb
@@ -11,6 +11,8 @@ in-target $late_command.late_file("""[main]
     classfile = $vardir/classes.txt
     localconfig = $vardir/localconfig
     server = %(puppet_master)s
+    report = false
+    configtimeout = 600
 """ % {"puppet_master": $puppet_master},
     "/etc/puppet/puppet.conf", source_method="content") \
     #else

--- a/deployment/puppet/mysql/lib/puppet/provider/database/mysql.rb
+++ b/deployment/puppet/mysql/lib/puppet/provider/database/mysql.rb
@@ -14,7 +14,15 @@ Puppet::Type.type(:database).provide(:mysql) do
   end
 
   def create
-    mysql('-NBe', "create database `#{@resource[:name]}` character set #{resource[:charset]}")
+    tries=10
+    begin
+        debug("Trying to create database #{@resource[:name]} ")
+        mysql('-NBe', "create database `#{@resource[:name]}` character set #{resource[:charset]}")
+    rescue
+        debug("Can't connect to the server: #{tries} tries to reconnect")
+        sleep 5
+        retry unless (tries -= 1) <= 0
+    end
   end
 
   def destroy


### PR DESCRIPTION
Puppet tries to create database when the mysql server has just started but can't accept the connection yet.
This patch fixes this problem. I
