### PR TITLE
Move swift root directory to /srv to prevent error

### DIFF
--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -57,7 +57,7 @@ else {
 
 if !$swift_partition
 {
-  $swift_partition = '/var/lib/glance/node'
+  $swift_partition = '/srv/node'
 }
 
 


### PR DESCRIPTION
Thre was file not found error because /var/lib/glance did not exist.
Why do we use  /var/lib/glance for swift root anyway? Let's use common location as in other deployment modes.
