### PR TITLE
fix rpmcache to use wildcards and rsync instead of cp

### DIFF
--- a/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
+++ b/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
@@ -1,113 +1,54 @@
-GeoIP-1.4.8-1.el6.x86_64.rpm
-MySQL-client-wsrep-5.5.28_wsrep_23.7-12.x86_64.rpm
-MySQL-python-1.2.3-0.3.c1.2.el6.x86_64.rpm
-MySQL-server-wsrep-5.5.28_wsrep_23.7-12.x86_64.rpm
-MySQL-shared-wsrep-5.5.28_wsrep_23.7-12.x86_64.rpm
-cirros-testvm-0.3.0-3.x86_64.rpm
-crmsh-1.2.5-55.2.x86_64.rpm
-c-ares19-1.9.1-4.el6.3.x86_64.rpm
-erlang-R14B-04.8.el6.x86_64.rpm
-erlang-appmon-R14B-04.8.el6.x86_64.rpm
-erlang-asn1-R14B-04.8.el6.x86_64.rpm
-erlang-common_test-R14B-04.8.el6.x86_64.rpm
-erlang-compiler-R14B-04.8.el6.x86_64.rpm
-erlang-cosEvent-R14B-04.8.el6.x86_64.rpm
-erlang-cosEventDomain-R14B-04.8.el6.x86_64.rpm
-erlang-cosFileTransfer-R14B-04.8.el6.x86_64.rpm
-erlang-cosNotification-R14B-04.8.el6.x86_64.rpm
-erlang-cosProperty-R14B-04.8.el6.x86_64.rpm
-erlang-cosTime-R14B-04.8.el6.x86_64.rpm
-erlang-cosTransactions-R14B-04.8.el6.x86_64.rpm
-erlang-crypto-R14B-04.8.el6.x86_64.rpm
-erlang-debugger-R14B-04.8.el6.x86_64.rpm
-erlang-dialyzer-R14B-04.8.el6.x86_64.rpm
-erlang-diameter-R14B-04.8.el6.x86_64.rpm
-erlang-docbuilder-R14B-04.8.el6.x86_64.rpm
-erlang-edoc-R14B-04.8.el6.x86_64.rpm
-erlang-erl_docgen-R14B-04.8.el6.x86_64.rpm
-erlang-erl_interface-R14B-04.8.el6.x86_64.rpm
-erlang-erts-R14B-04.8.el6.x86_64.rpm
-erlang-et-R14B-04.8.el6.x86_64.rpm
-erlang-eunit-R14B-04.8.el6.x86_64.rpm
-erlang-examples-R14B-04.8.el6.x86_64.rpm
-erlang-gs-R14B-04.8.el6.x86_64.rpm
-erlang-hipe-R14B-04.8.el6.x86_64.rpm
-erlang-ic-R14B-04.8.el6.x86_64.rpm
-erlang-inets-R14B-04.8.el6.x86_64.rpm
-erlang-inviso-R14B-04.8.el6.x86_64.rpm
-erlang-jinterface-R14B-04.8.el6.x86_64.rpm
-erlang-kernel-R14B-04.8.el6.x86_64.rpm
-erlang-megaco-R14B-04.8.el6.x86_64.rpm
-erlang-mnesia-R14B-04.8.el6.x86_64.rpm
-erlang-observer-R14B-04.8.el6.x86_64.rpm
-erlang-odbc-R14B-04.8.el6.x86_64.rpm
-erlang-orber-R14B-04.8.el6.x86_64.rpm
-erlang-os_mon-R14B-04.8.el6.x86_64.rpm
-erlang-otp_mibs-R14B-04.8.el6.x86_64.rpm
-erlang-parsetools-R14B-04.8.el6.x86_64.rpm
-erlang-percept-R14B-04.8.el6.x86_64.rpm
-erlang-pman-R14B-04.8.el6.x86_64.rpm
-erlang-public_key-R14B-04.8.el6.x86_64.rpm
-erlang-reltool-R14B-04.8.el6.x86_64.rpm
-erlang-runtime_tools-R14B-04.8.el6.x86_64.rpm
-erlang-sasl-R14B-04.8.el6.x86_64.rpm
-erlang-snmp-R14B-04.8.el6.x86_64.rpm
-erlang-ssh-R14B-04.8.el6.x86_64.rpm
-erlang-ssl-R14B-04.8.el6.x86_64.rpm
-erlang-stdlib-R14B-04.8.el6.x86_64.rpm
-erlang-syntax_tools-R14B-04.8.el6.x86_64.rpm
-erlang-test_server-R14B-04.8.el6.x86_64.rpm
-erlang-toolbar-R14B-04.8.el6.x86_64.rpm
-erlang-tools-R14B-04.8.el6.x86_64.rpm
-erlang-tv-R14B-04.8.el6.x86_64.rpm
-erlang-typer-R14B-04.8.el6.x86_64.rpm
-erlang-webtool-R14B-04.8.el6.x86_64.rpm
-erlang-wx-R14B-04.8.el6.x86_64.rpm
-erlang-xmerl-R14B-04.8.el6.x86_64.rpm
-euca2ools-2.1.3-1.el6.noarch.rpm
-galera-23.2.2-1.rhel5.x86_64.rpm
-http-parser-2.0-4.20121128gitcd01361.el6.x86_64.rpm
-libicu-4.2.1-9.1.el6_2.x86_64.rpm
-libuv-0.10.4-1.el6.x86_64.rpm
-mcollective-2.3.1-2.el6.noarch.rpm
-mcollective-client-2.3.1-2.el6.noarch.rpm
-mcollective-common-2.3.1-2.el6.noarch.rpm
-nailgun-agent-0.1.0-1.x86_64.rpm
-nailgun-mcagents-0.1.0-1.x86_64.rpm
-nailgun-net-check-0.0.2-1.x86_64.rpm
-nginx-1.0.15-4.el6.x86_64.rpm
-nodejs-0.10.4-1.el6.x86_64.rpm
-nodejs-less-1.3.3-3.el6.noarch.rpm
-pssh-2.3.1-15.2.x86_64.rpm
-puppet-2.7.19-1.el6.noarch.rpm
-python-amqp-1.2.0-6.el6.noarch.rpm
-python-amqplib-1.0.2-1.el6.noarch.rpm
-python-anyjson-0.3.3-2.el6.noarch.rpm
-python-importlib-1.0.2-1.el6.noarch.rpm
-python-kombu-2.4.7-3.el6.noarch.rpm
-python-meld3-0.6.7-1.el6.x86_64.rpm
-python-ordereddict-1.1-2.el6.noarch.rpm
-python-pip-0.8-1.el6.noarch.rpm
-python-virtualenv-1.7.2-1.el6.noarch.rpm
-rabbitmq-server-2.8.7-2.el6.noarch.rpm
-ruby-ri-1.8.7.352-10.el6_4.x86_64.rpm
-rubygem-daemons-1.0.10-2.el6.noarch.rpm
-rubygem-fastthread-1.0.7-2.el6.x86_64.rpm
-rubygem-gem_plugin-0.2.3-3.el6.noarch.rpm
-rubygem-mongrel-1.1.5-3.el6.x86_64.rpm
-rubygem-netaddr-1.5.0-3.el6.noarch.rpm
-rubygem-openstack-1.1.1-3.el6.noarch.rpm
-rubygem-json-1.7.7-101.el6.x86_64.rpm
-rubygem-rake-0.8.7-2.el6.noarch.rpm
-rubygem-stomp-1.2.8-1.el6.noarch.rpm
-rubygems-1.3.7-1.el6.noarch.rpm
-scapy-2.0.0.10-5.el6.noarch.rpm
-socat-1.7.2.2-1.el6.x86_64.rpm
-supervisor-3.0a12-0.12.el6.noarch.rpm
-tinyproxy-1.8.2-1.el6.x86_64.rpm
-v8-3.14.5.7-3.el6.x86_64.rpm
-wxBase-2.8.12-2.el6.x86_64.rpm
-wxGTK-2.8.12-2.el6.x86_64.rpm
-wxGTK-gl-2.8.12-2.el6.x86_64.rpm
-xfsprogs-3.1.1-10.el6.x86_64.rpm
-xinetd-2.3.14-38.el6.x86_64.rpm
+# This file is used by rsync
+# Format + pkgname
+# Comments are ignored by rsync
+# Exclude is "- pattern"
++ GeoIP*
++ MySQL*
++ MySQL-python*
++ cirros-testvm*
++ crmsh*
++ c-ares19*
++ erlang*
++ euca2ools*
++ galera*
++ http-parser*
++ libicu*
++ libuv*
++ mcollective*
++ nailgun*
++ nginx*
++ nodejs*
++ pssh*
++ puppet-*
++ python-amqp*
++ python-amqplib*
++ python-anyjson*
++ python-importlib*
++ python-kombu*
++ python-meld3*
++ python-ordereddict*
++ python-pip*
++ python-virtualenv*
++ rabbitmq-server*
++ ruby-ri*
++ rubygem-daemons*
++ rubygem-fastthread
++ rubygem-gem_plugin
++ rubygem-mongrel*
++ rubygem-netaddr*
++ rubygem-openstack*
++ rubygem-json*
++ rubygem-rake*
++ rubygem-stomp*
++ rubygems-*
++ scapy*
++ socat*
++ supervisor*
++ tinyproxy*
++ v8*
++ wxBase*
++ wxGTK*
++ xfsprogs*
++ xinetd*
+# Do not remove this line
+- *.rpm

--- a/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
+++ b/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
@@ -3,7 +3,7 @@
 # Comments are ignored by rsync
 # Exclude is "- pattern"
 + GeoIP*
-+ MySQL*
++ MySQL*wsrep*
 + MySQL-python*
 + cirros-testvm*
 + crmsh*

--- a/deployment/puppet/rpmcache/manifests/init.pp
+++ b/deployment/puppet/rpmcache/manifests/init.pp
@@ -129,7 +129,7 @@ $sat_base_channels, $sat_openstack_channel, $numtries = 10)  {
     require => File['/etc/nailgun/']
   } ->
   exec {'fuel-rpms':
-    command => "/bin/mkdir -p ${pkgdir}/fuel/Packages; /bin/cat /etc/nailgun/req-fuel-rhel.txt | /usr/bin/xargs -n 1 -I xxx /bin/cp /var/www/nailgun/centos/fuelweb/x86_64/Packages/xxx ${pkgdir}/fuel/Packages/",
+    command => "/bin/mkdir -p ${pkgdir}/fuel/Packages; rsync -ra --include-from=/etc/nailgun/req-fuel-rhel.txt /var/www/nailgun/centos/fuelweb/x86_64/Packages/. ${pkgdir}/fuel/Packages/.",
     logoutput => true,
     before    => Exec['rebuild-fuel-repo'],
   }


### PR DESCRIPTION
Change method to copy Fuel packages for RHOS deployment to Rsync instead of cp.
