### PR TITLE
Puppet parser function for frtch network information aboun network roles.

### DIFF
--- a/deployment/puppet/l23network/lib/puppet/parser/functions/get_network_role_property.rb
+++ b/deployment/puppet/l23network/lib/puppet/parser/functions/get_network_role_property.rb
@@ -1,0 +1,84 @@
+require 'ipaddr'
+begin
+  require 'puppet/parser/functions/lib/prepare_cidr.rb'
+rescue LoadError => e
+  # puppet apply does not add module lib directories to the $LOAD_PATH (See
+  # #4248). It should (in the future) but for the time being we need to be
+  # defensive which is what this rescue block is doing.
+  rb_file = File.join(File.dirname(__FILE__),'lib','prepare_cidr.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
+
+Puppet::Parser::Functions::newfunction(:get_network_role_property, :type => :rvalue, :doc => <<-EOS
+    This function get get network config Hash, network_role name and mode --
+    and return information about network role.
+
+    ex: get_network_role_property(hash, 'admin', 'interface')
+
+    You can use following modes:
+      interface -- network interface for the network_role
+      ipaddr -- IP address for the network_role
+      cidr -- CIDR-notated IP addr and mask for the network_role
+      netmask -- string, contains dotted nemmask
+      ipaddr_netmask_pair -- list of ipaddr and netmask
+
+    EOS
+  ) do |argv|
+  if argv.size == 3
+    mode = argv[2].to_s().upcase()
+  else
+      raise(Puppet::ParseError, "get_network_role_property(cfg_hash, role_name): Wrong number of arguments.")
+  end
+  cfg = sanitize_hash(argv[0])
+  network_role = argv[1].to_sym()
+
+  if !cfg[:roles] || !cfg[:endpoints] || cfg[:roles].class.to_s() != "Hash" || cfg[:endpoints].class.to_s() != "Hash"
+      raise(Puppet::ParseError, "get_network_role_property(cfg_hash, role_name): Invalid cfg_hash format.")
+  end
+
+  # search interface for role
+  interface = cfg[:roles][network_role]
+  if !interface
+      raise(Puppet::ParseError, "get_network_role_property(cfg_hash, role_name): Undefined network_role '#{network_role}'.")
+  end
+
+  # get endpoint configuration hash for interface
+  ep = cfg[:endpoints][interface.to_sym()]
+  if !ep
+      raise(Puppet::ParseError, "get_network_role_property(cfg_hash, role_name): Can't find interface '#{interface}' in endpoints for network_role '#{network_role}'.")
+  end
+
+  if mode == 'INTERFACE'
+    return interface.to_s
+  end
+
+  case ep[:IP].class().to_s()
+    when "Array"
+      ipaddr_cidr = ep[:IP][0] ? ep[:IP][0] : nil
+    when "String"
+      #raise(Puppet::ParseError, "get_network_role_property(cfg_hash, role_name): Can't determine dynamic or empty IP address for endpoint '#{interface}' (#{ep[:IP]}).")
+      ipaddr_cidr = nil
+    else
+      raise(Puppet::ParseError, "get_network_role_property(cfg_hash, role_name): invalid IP address for endpoint '#{interface}'.")
+  end
+
+  if ipaddr_cidr == nil
+    return nil
+  end
+
+  case mode
+    when 'CIDR'
+      return ipaddr_cidr
+    when 'NETMASK'
+      return IPAddr.new('255.255.255.255').mask(prepare_cidr(ipaddr_cidr)[1]).to_s()
+    when 'IPADDR'
+      return prepare_cidr(ipaddr_cidr)[0].to_s()
+    when 'IPADDR_NETMASK_PAIR'
+      return prepare_cidr(ipaddr_cidr)[0].to_s(), IPAddr.new('255.255.255.255').mask(prepare_cidr(ipaddr_cidr)[1]).to_s()
+    end
+
+
+
+end
+
+# vim: set ts=2 sw=2 et :

--- a/deployment/puppet/l23network/lib/puppet/parser/functions/get_network_role_property.rb
+++ b/deployment/puppet/l23network/lib/puppet/parser/functions/get_network_role_property.rb
@@ -8,6 +8,15 @@ rescue LoadError => e
   rb_file = File.join(File.dirname(__FILE__),'lib','prepare_cidr.rb')
   load rb_file if File.exists?(rb_file) or raise e
 end
+begin
+  require 'puppet/parser/functions/lib/sanitize_hash.rb'
+rescue LoadError => e
+  # puppet apply does not add module lib directories to the $LOAD_PATH (See
+  # #4248). It should (in the future) but for the time being we need to be
+  # defensive which is what this rescue block is doing.
+  rb_file = File.join(File.dirname(__FILE__),'lib','sanitize_hash.rb')
+  load rb_file if File.exists?(rb_file) or raise e
+end
 
 Puppet::Parser::Functions::newfunction(:get_network_role_property, :type => :rvalue, :doc => <<-EOS
     This function get get network config Hash, network_role name and mode --

--- a/deployment/puppet/l23network/lib/puppet/parser/functions/lib/prepare_cidr.rb
+++ b/deployment/puppet/l23network/lib/puppet/parser/functions/lib/prepare_cidr.rb
@@ -1,16 +1,16 @@
 def prepare_cidr(cidr)
-  if ! cidr.is_a?(String)
+  if !cidr.is_a?(String)
     raise(Puppet::ParseError, "Can't recognize IP address in non-string data.")
   end
 
   re_groups = /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\/(\d{1,2})$/.match(cidr)
-  if ! re_groups or re_groups[2].to_i > 32
+  if !re_groups or re_groups[2].to_i > 32
     raise(Puppet::ParseError, "cidr_to_ipaddr(): Wrong CIDR: '#{cidr}'.")
-  end 
-  
+  end
+
   for octet in re_groups[1].split('.')
     raise(Puppet::ParseError, "cidr_to_ipaddr(): Wrong CIDR: '#{cidr}'.") if octet.to_i > 255
   end
-  
+
   return re_groups[1], re_groups[2].to_i
 end

--- a/deployment/puppet/l23network/lib/puppet/parser/functions/lib/sanitize_hash.rb
+++ b/deployment/puppet/l23network/lib/puppet/parser/functions/lib/sanitize_hash.rb
@@ -1,0 +1,31 @@
+def sanitize_hash(cfg)
+  def process_array(aa)
+    rv = []
+    aa.each do |v|
+      if v.is_a? Hash
+        rv.insert(-1, process_hash(v))
+      elsif v.is_a? Array
+        rv.insert(-1, process_array(v))
+      else
+        rv.insert(-1, v)
+      end
+    end
+    return rv
+  end
+  def process_hash(hh)
+    rv = {}
+    hh.each do |k, v|
+      #info("xx>>#{k}--#{k.to_sym}<<")
+      if v.is_a? Hash
+        rv[k.to_sym] = process_hash(v)
+      elsif v.is_a? Array
+        rv[k.to_sym] = process_array(v)
+      else
+        rv[k.to_sym] = v
+      end
+    end
+    return rv
+  end
+  process_hash(cfg)
+end
+# vim: set ts=2 sw=2 et :

--- a/deployment/puppet/l23network/spec/functions/get_network_role_property__spec.rb
+++ b/deployment/puppet/l23network/spec/functions/get_network_role_property__spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe 'get_network_role_property' do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+  let(:cfg) do
+    {
+      :endpoints => {
+        :eth0 => {:IP => 'dhcp'},
+        :"br-ex" => {
+          :gateway => '10.1.3.1',
+          :IP => ['10.1.3.11/24'],
+        },
+        :"br-mgmt" => { :IP => ['10.20.1.11/25'] },
+        :"br-storage" => { :IP => ['192.168.1.2/24'] },
+        :"br-prv" => { :IP => 'none' },
+      },
+      :roles => {
+        :management => 'br-mgmt',
+        :private => 'br-prv',
+        :ex => 'br-ex',
+        :storage => 'br-storage',
+        :admin => 'eth0',
+      },
+    }
+  end
+
+  it 'should exist' do
+    Puppet::Parser::Functions.function('get_network_role_property').should == 'function_get_network_role_property'
+  end
+
+  it 'should return interface name for "private" network role' do
+    should run.with_params(cfg, 'private', 'interface').and_return('br-prv')
+  end
+
+  it 'should raise for non-existing role name' do
+    should run.with_params(cfg, 'not_exist', 'interface').and_raise_error(Puppet::ParseError)
+  end
+
+  it 'should return ip address for "management" network role' do
+    should run.with_params(cfg, 'management', 'ipaddr').and_return('10.20.1.11')
+  end
+
+  it 'should return cidr-notated ip address for "management" network role' do
+    should run.with_params(cfg, 'management', 'cidr').and_return('10.20.1.11/25')
+  end
+
+  it 'should return netmask for "management" network role' do
+    should run.with_params(cfg, 'management', 'netmask').and_return('255.255.255.128')
+  end
+
+  it 'should return ip address and netmask for "management" network role' do
+    should run.with_params(cfg, 'management', 'ipaddr_netmask_pair').and_return(['10.20.1.11','255.255.255.128'])
+  end
+
+  it 'should return NIL for "admin" network role' do
+    should run.with_params(cfg, 'admin', 'netmask').and_return(nil)
+  end
+  it 'should return NIL for "admin" network role' do
+    should run.with_params(cfg, 'admin', 'ipaddr').and_return(nil)
+  end
+  it 'should return NIL for "admin" network role' do
+    should run.with_params(cfg, 'admin', 'cidr').and_return(nil)
+  end
+  it 'should return NIL for "admin" network role' do
+    should run.with_params(cfg, 'admin', 'ipaddr_netmask_pair').and_return(nil)
+  end
+
+end


### PR DESCRIPTION
This function get get network config Hash, network_role name and mode -- and return information about network role.

ex: 

``` ruby
get_network_role_property(network_config_hash, 'admin', 'interface')
```

You can use following modes:
      interface -- network interface for the network_role
      ipaddr -- IP address for the network_role
      cidr -- CIDR-notated IP addr and mask for the network_role
      netmask -- string, contains dotted nemmask
      ipaddr_netmask_pair -- list of ipaddr and netmask
