### PR TITLE
Refactored cobbler deployment for astute.yaml

### DIFF
--- a/deployment/puppet/nailgun/examples/site.pp
+++ b/deployment/puppet/nailgun/examples/site.pp
@@ -1,3 +1,5 @@
+$fuel_settings = parseyaml($astute_settings_yaml)
+
 node default {
 
   Exec  {path => '/usr/bin:/bin:/usr/sbin:/sbin'}
@@ -27,7 +29,7 @@ node default {
 
   $repo_root = "/var/www/nailgun"
   $pip_repo = "/var/www/nailgun/eggs"
-  $gem_source = "http://${mnbs_internal_ipaddress}:8080/gems/"
+  $gem_source = "http://${::fuel_settings['ADMIN_NETWORK']['ipaddress']}:8080/gems/"
 
   class { 'postgresql::server':
     config_hash => {
@@ -66,7 +68,7 @@ node default {
 
     mco_pskey => $mco_pskey,
     mco_vhost => $mco_vhost,
-    mco_host => $mnbs_internal_ipaddress,
+    mco_host => $::fuel_settings['ADMIN_NETWORK']['address'],
     mco_user => $mco_user,
     mco_password => $mco_password,
     mco_connector => "rabbitmq",
@@ -74,7 +76,7 @@ node default {
     rabbitmq_naily_user => $rabbitmq_naily_user,
     rabbitmq_naily_password => $rabbitmq_naily_password,
     puppet_master_hostname => $puppet_master_hostname,
-    puppet_master_ip => $mnbs_internal_ipaddress,
+    puppet_master_ip => $::fuel_settings['ADMIN_NETWORK']['address'],
   }
 
   Class['postgresql::server'] -> Class['nailgun']

--- a/deployment/puppet/nailgun/examples/site.pp
+++ b/deployment/puppet/nailgun/examples/site.pp
@@ -66,6 +66,7 @@ node default {
 
     mco_pskey => $mco_pskey,
     mco_vhost => $mco_vhost,
+    mco_host => $mnbs_internal_ipaddress,
     mco_user => $mco_user,
     mco_password => $mco_password,
     mco_connector => "rabbitmq",

--- a/deployment/puppet/nailgun/examples/site.pp
+++ b/deployment/puppet/nailgun/examples/site.pp
@@ -27,7 +27,7 @@ node default {
 
   $repo_root = "/var/www/nailgun"
   $pip_repo = "/var/www/nailgun/eggs"
-  $gem_source = "http://${ipaddress}:8080/gems/"
+  $gem_source = "http://${mnbs_internal_ipaddress}:8080/gems/"
 
   class { 'postgresql::server':
     config_hash => {

--- a/deployment/puppet/nailgun/examples/site.pp
+++ b/deployment/puppet/nailgun/examples/site.pp
@@ -74,6 +74,7 @@ node default {
     rabbitmq_naily_user => $rabbitmq_naily_user,
     rabbitmq_naily_password => $rabbitmq_naily_password,
     puppet_master_hostname => $puppet_master_hostname,
+    puppet_master_ip => $mnbs_internal_ipaddress,
   }
 
   Class['postgresql::server'] -> Class['nailgun']

--- a/deployment/puppet/nailgun/manifests/cobbler.pp
+++ b/deployment/puppet/nailgun/manifests/cobbler.pp
@@ -20,17 +20,17 @@ class nailgun::cobbler(
   Anchor<| title == "nailgun-cobbler-end" |>
 
   class { "::cobbler":
-    server              => $mnbs_internal_ipaddress,
+    server              => $::fuel_settings['ADMIN_NETWORK']['ipaddress'],
 
     domain_name         => $domain,
-    name_server         => $mnbs_internal_ipaddress,
-    next_server         => $mnbs_internal_ipaddress,
+    name_server         => $::fuel_settings['ADMIN_NETWORK']['ipaddress'],
+    next_server         => $::fuel_settings['ADMIN_NETWORK']['ipaddress'],
 
-    dhcp_start_address  => $mnbs_dhcp_pool_start,
-    dhcp_end_address    => $mnbs_dhcp_pool_end,
-    dhcp_netmask        => $mnbs_internal_netmask,
-    dhcp_gateway        => $mnbs_internal_ipaddress,
-    dhcp_interface      => $mnbs_internal_interface,
+    dhcp_start_address  => $::fuel_settings['ADMIN_NETWORK']['dhcp_pool_start'],
+    dhcp_end_address    => $::fuel_settings['ADMIN_NETWORK']['dhcp_pool_end'],
+    dhcp_netmask        => $::fuel_settings['ADMIN_NETWORK']['netmask'],
+    dhcp_gateway        => $::fuel_settings['ADMIN_NETWORK']['ipaddress'],
+    dhcp_interface      => $::fuel_settings['ADMIN_NETWORK']['interface'],
 
     cobbler_user        => $cobbler_user,
     cobbler_password    => $cobbler_password,
@@ -106,7 +106,7 @@ class nailgun::cobbler(
     distro => "bootstrap",
     menu => true,
     kickstart => "",
-    kopts => "biosdevname=0 url=http://${mnbs_internal_ipaddress}:8000/api",
+    kopts => "biosdevname=0 url=http://${::fuel_settings['ADMIN_NETWORK']['ipaddress']}:8000/api",
     ksmeta => "",
     require => Cobbler_distro["bootstrap"],
   }

--- a/deployment/puppet/nailgun/manifests/cobbler.pp
+++ b/deployment/puppet/nailgun/manifests/cobbler.pp
@@ -19,20 +19,18 @@ class nailgun::cobbler(
   Class["::cobbler"] ->
   Anchor<| title == "nailgun-cobbler-end" |>
 
-  $half_of_network = ipcalc_network_count_addresses($ipaddress, $netmask) / 2
-
   class { "::cobbler":
-    server              => $ipaddress,
+    server              => $mnbs_internal_ipaddress,
 
     domain_name         => $domain,
-    name_server         => $ipaddress,
-    next_server         => $ipaddress,
+    name_server         => $mnbs_internal_ipaddress,
+    next_server         => $mnbs_internal_ipaddress,
 
-    dhcp_start_address  => ipcalc_network_nth_address($ipaddress, $netmask, "first"),
-    dhcp_end_address    => ipcalc_network_nth_address($ipaddress, $netmask, $half_of_network),
-    dhcp_netmask        => $netmask,
-    dhcp_gateway        => $ipaddress,
-    dhcp_interface      => 'eth0',
+    dhcp_start_address  => $mnbs_dhcp_pool_start,
+    dhcp_end_address    => $mnbs_dhcp_pool_end,
+    dhcp_netmask        => $mnbs_internal_netmask,
+    dhcp_gateway        => $mnbs_internal_ipaddress,
+    dhcp_interface      => $mnbs_internal_interface,
 
     cobbler_user        => $cobbler_user,
     cobbler_password    => $cobbler_password,
@@ -108,7 +106,7 @@ class nailgun::cobbler(
     distro => "bootstrap",
     menu => true,
     kickstart => "",
-    kopts => "biosdevname=0 url=http://${ipaddress}:8000/api",
+    kopts => "biosdevname=0 url=http://${mnbs_internal_ipaddress}:8000/api",
     ksmeta => "",
     require => Cobbler_distro["bootstrap"],
   }
@@ -137,10 +135,5 @@ class nailgun::cobbler(
   Exec["cobbler_system_add_default"] ~> Exec["nailgun_cobbler_sync"]
   Exec["cobbler_system_edit_default"] ~> Exec["nailgun_cobbler_sync"]
 
-  #FIXME: do we really need this NAT rules ?
-  #  class { 'cobbler::nat': nat_range => \"$dhcp_start_address/$dhcp_netmask\" }
-
-  #  Package<| title == "cman" |>
-  # Package<| title == "fence-agents"|>
 }
 

--- a/deployment/puppet/nailgun/manifests/init.pp
+++ b/deployment/puppet/nailgun/manifests/init.pp
@@ -32,7 +32,7 @@ class nailgun(
   $mco_connector = "rabbitmq",
 
   $naily_version,
-  $nailgun_api_url = "http://${mnbs_internal_ipaddress}:8000/api",
+  $nailgun_api_url = "http://{$::fuel_settings['ADMIN_NETWORK']['ipaddress']}:8000/api",
   $rabbitmq_naily_user = "naily",
   $rabbitmq_naily_password = "naily",
   $puppet_master_hostname = "${hostname}.${domain}",
@@ -121,13 +121,12 @@ class nailgun(
     rabbitmq_naily_user => $rabbitmq_naily_user,
     rabbitmq_naily_password => $rabbitmq_naily_password,
 
-    admin_network => ipcalc_network_by_address_netmask($mnbs_internal_ipaddress, $mnbs_internal_netmask),
-    admin_network_cidr => ipcalc_network_cidr_by_netmask($mnbs_internal_netmask),
-    admin_network_size => ipcalc_network_count_addresses($mnbs_internal_ipaddress, $mnbs_internal_netmask),
-    admin_network_first => $mnbs_static_pool_start,
-    admin_network_last => $mnbs_static_pool_end,
-    admin_network_netmask => $mnbs_internal_netmask,
-    admin_network_ip => $mnbs_internal_ipaddress,
+    admin_network => ipcalc_network_by_address_netmask($::fuel_settings['ADMIN_NETWORK']['ipaddress'], $::fuel_settings['ADMIN_NETWORK']['netmask']),
+    admin_network_cidr => ipcalc_network_cidr_by_netmask($::fuel_settings['ADMIN_NETWORK']['netmask']),
+    admin_network_size => ipcalc_network_count_addresses($::fuel_settings['ADMIN_NETWORK']['ipaddress'], $::fuel_settings['ADMIN_NETWORK']['netmask']),
+    admin_network_first => $::fuel_settings['ADMIN_NETWORK']['static_pool_start'],
+    admin_network_last => $::fuel_settings['ADMIN_NETWORK']['static_pool_end'],
+    admin_network_netmask => $::fuel_settings['ADMIN_NETWORK']['netmask'],
 
   }
 

--- a/deployment/puppet/nailgun/manifests/init.pp
+++ b/deployment/puppet/nailgun/manifests/init.pp
@@ -120,6 +120,15 @@ class nailgun(
     templatedir => $templatedir,
     rabbitmq_naily_user => $rabbitmq_naily_user,
     rabbitmq_naily_password => $rabbitmq_naily_password,
+
+    admin_network => ipcalc_network_by_address_netmask($mnbs_internal_ipaddress, $mnbs_internal_netmask),
+    admin_network_cidr => ipcalc_network_cidr_by_netmask($mnbs_internal_netmask),
+    admin_network_size => ipcalc_network_count_addresses($mnbs_internal_ipaddress, $mnbs_internal_netmask),
+    admin_network_first => $mnbs_static_pool_start,
+    admin_network_last => $mnbs_static_pool_end,
+    admin_network_netmask => $mnbs_internal_netmask,
+    admin_network_ip => $mnbs_internal_ipaddress,
+
   }
 
   class {"nailgun::naily":

--- a/deployment/puppet/nailgun/manifests/init.pp
+++ b/deployment/puppet/nailgun/manifests/init.pp
@@ -32,7 +32,7 @@ class nailgun(
   $mco_connector = "rabbitmq",
 
   $naily_version,
-  $nailgun_api_url = "http://$ipaddress:8000/api",
+  $nailgun_api_url = "http://${mnbs_internal_ipaddress}:8000/api",
   $rabbitmq_naily_user = "naily",
   $rabbitmq_naily_password = "naily",
   $puppet_master_hostname = "${hostname}.${domain}",

--- a/deployment/puppet/nailgun/manifests/iptables.pp
+++ b/deployment/puppet/nailgun/manifests/iptables.pp
@@ -21,7 +21,7 @@ class nailgun::iptables {
 
   access_to_nailgun_port { "nailgun_web":    port => '8000' }
   access_to_nailgun_port { "nailgun_repo":    port => '8080' }
-  $network_address = ipcalc_network_by_address_netmask($mnbs_internal_ipaddress, $mnbs_internal_netmask)
-  $network_cidr = ipcalc_network_cidr_by_netmask($mnbs_internal_netmask)
+  $network_address = ipcalc_network_by_address_netmask($::fuel_settings['ADMIN_NETWORK']['ipaddress'],$::fuel_settings['ADMIN_NETWORK']['netmask'])
+  $network_cidr = ipcalc_network_cidr_by_netmask($::fuel_settings['ADMIN_NETWORK']['netmask'])
   ip_forward {'forward_slaves': network => "${network_address}/${network_cidr}"}
 }

--- a/deployment/puppet/nailgun/manifests/iptables.pp
+++ b/deployment/puppet/nailgun/manifests/iptables.pp
@@ -10,7 +10,7 @@ class nailgun::iptables {
   }
 
   define ip_forward($network) {
-    $rule = "--source $network -j MASQUERADE"
+    $rule = "-s $network -j MASQUERADE"
     exec { "ip_forward: $network":
       command => "iptables -t nat -I POSTROUTING 1 $rule; \
       /etc/init.d/iptables save",
@@ -21,5 +21,7 @@ class nailgun::iptables {
 
   access_to_nailgun_port { "nailgun_web":    port => '8000' }
   access_to_nailgun_port { "nailgun_repo":    port => '8080' }
-  ip_forward {'forward_slaves': network => "${mnbs_internal_ipaddress}/${mnbs_internal_netmask}"}
+  $network_address = ipcalc_network_by_address_netmask($mnbs_internal_ipaddress, $mnbs_internal_netmask)
+  $network_cidr = ipcalc_network_cidr_by_netmask($mnbs_internal_netmask)
+  ip_forward {'forward_slaves': network => "${network_address}/${network_cidr}"}
 }

--- a/deployment/puppet/nailgun/manifests/iptables.pp
+++ b/deployment/puppet/nailgun/manifests/iptables.pp
@@ -21,5 +21,5 @@ class nailgun::iptables {
 
   access_to_nailgun_port { "nailgun_web":    port => '8000' }
   access_to_nailgun_port { "nailgun_repo":    port => '8080' }
-  ip_forward {'forward_slaves': network => "${ipaddress}/${netmask}"}
+  ip_forward {'forward_slaves': network => "${mnbs_internal_ipaddress}/${mnbs_internal_netmask}"}
 }

--- a/deployment/puppet/nailgun/manifests/mcollective.pp
+++ b/deployment/puppet/nailgun/manifests/mcollective.pp
@@ -3,6 +3,7 @@ class nailgun::mcollective(
   $mco_user = "mcollective",
   $mco_password = "marionette",
   $mco_vhost = "mcollective",
+  $mco_host = "localhost",
   ){
 
   class { "mcollective::rabbitmq":
@@ -16,7 +17,7 @@ class nailgun::mcollective(
     vhost => $mco_vhost,
     user => $mco_user,
     password => $mco_password,
-    host => $ipaddress,
+    host => $mco_host,
     stomp => false,
   }
    class { "mcollective::server":
@@ -24,7 +25,7 @@ class nailgun::mcollective(
     vhost => $mco_vhost,
     user => $mco_user,
     password => $mco_password,
-    host => $ipaddress,
+    host => $mco_host,
     stomp => false,
   }
  

--- a/deployment/puppet/nailgun/manifests/venv.pp
+++ b/deployment/puppet/nailgun/manifests/venv.pp
@@ -20,6 +20,18 @@ class nailgun::venv(
 
   $rabbitmq_naily_user,
   $rabbitmq_naily_password,
+
+  $admin_network,
+  $admin_network_cidr,
+  $admin_network_size,
+  $admin_network_first,
+  $admin_network_last,
+  $admin_network_netmask,
+  $admin_network_ip,
+
+  $exclude_network = $admin_network,
+  $exclude_cidr = $admin_network_cidr,
+
   ) {
 
   nailgun::venv::venv { $venv:
@@ -63,16 +75,6 @@ class nailgun::venv(
     mode => 0755,
   }
 
-  $exclude_network = ipcalc_network_by_address_netmask($ipaddress, $netmask)
-  $exclude_cidr = ipcalc_network_cidr_by_netmask($netmask)
-
-  $admin_network = ipcalc_network_by_address_netmask($ipaddress, $netmask)
-  $admin_network_cidr = ipcalc_network_cidr_by_netmask($netmask)
-  $admin_network_size = ipcalc_network_count_addresses($ipaddress, $netmask)
-  $first_in_second_half = ipcalc_network_count_addresses($ipaddress, $netmask) / 2 + 1
-  $admin_network_first = ipcalc_network_nth_address($ipaddress, $netmask, $first_in_second_half)
-  $admin_network_last = ipcalc_network_nth_address($ipaddress, $netmask, "last")
-  $admin_network_netmask = $netmask
 
   file { "/etc/nailgun/settings.yaml":
     content => template("nailgun/settings.yaml.erb"),

--- a/deployment/puppet/nailgun/templates/settings.yaml.erb
+++ b/deployment/puppet/nailgun/templates/settings.yaml.erb
@@ -47,7 +47,7 @@ API_LOG: "/var/log/nailgun/api.log"
 PATH_TO_SSH_KEY: "/root/.ssh/id_rsa"
 PATH_TO_BOOTSTRAP_SSH_KEY: "/root/.ssh/bootstrap.rsa"
 
-MASTER_IP: "<%= ipaddress %>"
+MASTER_IP: "<%= admin_network_ip %>"
 
 COBBLER_URL: "<%= scope.lookupvar('nailgun::cobbler_url') %>"
 COBBLER_USER: "<%= cobbler_user %>"


### PR DESCRIPTION
Facts will move from naily.facts to /etc/astute.yaml and be stored in $::fuel_settings. This pull request depends on
https://github.com/Mirantis/fuel/pull/572/

Don't approve before 572
