### PR TITLE
Ubuntu Ceph-related disk changes

### DIFF
--- a/deployment/puppet/cobbler/templates/scripts/pmanager.py
+++ b/deployment/puppet/cobbler/templates/scripts/pmanager.py
@@ -472,7 +472,7 @@ class PreseedPManager(object):
         self.recipe("1 1 -1 linux-swap method{ swap } format{ } .")
         self.late("sed -i /$(blkid -s UUID -o value {0}7)/d /target/etc/fstab".format(self.disks[0]))
         self.late("swapoff {0}7".format(self.disks[0]))
-        self.late("parted {0} rm 7".format(self.disks[0]))
+        self.late("parted {0} rm 7".format(self.disks[0]), True)
 
     def _parttype(self, n):
         if n == 1:
@@ -489,21 +489,21 @@ class PreseedPManager(object):
                 pcount = self.pcount("/dev/%s" % disk["name"], 1)
                 tabmount = part["mount"] if part["mount"] != "swap" else "none"
                 if pcount == 1:
-                    self.late("parted -s /dev/{0} mklabel msdos".format(disk["name"]))
+                    self.late("parted -s /dev/{0} mklabel msdos".format(disk["name"]), True)
                 self.late("parted -a none -s /dev/{0} "
                           "unit {4} mkpart {1} {2} {3}".format(
                              disk["name"],
                              self._parttype(pcount),
                              self.psize("/dev/%s" % disk["name"]),
                              self.psize("/dev/%s" % disk["name"], part["size"] * self.factor),
-                             self.unit))
+                             self.unit), True)
                 if pcount == 1:
                     self.late("parted -a none -s /dev/{0} unit {1} "
                               "mkpart extended {2} {3}".format(
                                 disk["name"],
                                 self.unit,
                                 end_size,
-                                disk["size"]))
+                                disk["size"]), True)
                     self.late("hdparm -z /dev/{0}".format(disk["name"]))
 
                 if not part.get("file_system", "xfs") in ("swap", None, "none"):
@@ -534,21 +534,21 @@ class PreseedPManager(object):
                 begin_size = self.psize("/dev/%s" % disk["name"])
                 end_size = self.psize("/dev/%s" % disk["name"], pv["size"] * self.factor)
                 if pcount == 1:
-                    self.late("parted -s /dev/{0} mklabel msdos".format(disk["name"]))
+                    self.late("parted -s /dev/{0} mklabel msdos".format(disk["name"]), True)
                 self.late("parted -a none -s /dev/{0} "
                           "unit {4} mkpart {1} {2} {3}".format(
                              disk["name"],
                              self._parttype(pcount),
                              begin_size,
                              end_size,
-                             self.unit))
+                             self.unit), True)
                 if pcount == 1:
                     self.late("parted -a none -s /dev/{0} unit {1} "
                               "mkpart extended {2} {3}".format(
                                 disk["name"],
                                 self.unit,
                                 end_size,
-                                disk["size"]))
+                                disk["size"]), True)
                     self.late("hdparm -z /dev/{0}".format(disk["name"]))
                 self.late("pvcreate /dev/{0}{1}".format(disk["name"], pcount))
                 if not devices_dict.get(pv["vg"]):


### PR DESCRIPTION
Change all parted commands to run in-target because parted doesn't exist in the Busybox environment.
Label file systems so Ceph can be configured. 
