### PR TITLE
PRD-1716: Fix default route for Centos

### DIFF
--- a/deployment/puppet/l23network/manifests/l3/defaultroute.pp
+++ b/deployment/puppet/l23network/manifests/l3/defaultroute.pp
@@ -17,6 +17,13 @@ define l23network::l3::defaultroute (
               file  => '/etc/sysconfig/network',
               key   => 'GATEWAY',
               value => $gateway,
+          } ->
+          # FIXME: we should not nuke the system with 'service network restart'...
+          # FIXME: but we should ensure default route will be created somehow
+          exec {'Add default route':
+              path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+              command => "route add default gw ${gateway} || true",
+              unless  => "netstat -r | grep -q 'default.*${gateway}'",
           }
         }
     }

--- a/deployment/puppet/l23network/manifests/l3/defaultroute.pp
+++ b/deployment/puppet/l23network/manifests/l3/defaultroute.pp
@@ -20,9 +20,9 @@ define l23network::l3::defaultroute (
           } ->
           # FIXME: we should not nuke the system with 'service network restart'...
           # FIXME: but we should ensure default route will be created somehow
-          exec {'Add default route':
+          exec {'Default route':
               path    => '/bin:/usr/bin:/sbin:/usr/sbin',
-              command => "route add default gw ${gateway} || true",
+              command => "ip route replace default via ${gateway} || true",
               unless  => "netstat -r | grep -q 'default.*${gateway}'",
           }
         }

--- a/deployment/puppet/l23network/manifests/l3/ifconfig.pp
+++ b/deployment/puppet/l23network/manifests/l3/ifconfig.pp
@@ -294,4 +294,9 @@ define l23network::l3::ifconfig (
     subscribe     => File["$interface_file"],
     refreshonly   => true,
   }
+
+  # Ensure default route will be put in the right order
+  if defined(L23network::L3::Defaultroute[$def_gateway]) {
+    L3_if_downup <||> -> Defaultroute[$def_gateway]
+  }
 }


### PR DESCRIPTION
Note: https://github.com/Mirantis/fuel/pull/662 depends on this one

ISSUE: Centos affected only.
For system wide configured gateway (/etc/sysconfig/network), there is no ensure 
it would has been applied as a default route. It will be applied only after node's 
reboot or network restart.

SOLUTION: 
We should avoid using "heavy" operations like 'service network restart', thus, 
we should create default route by manually adding it into routing table while 
its config stage (adding GATEWAY to /etc/sysconfig/network) is being executed as well.

We should also ensure right apply order as well (L3_if_downup <||> -> Defaultroute[$def_gateway])
