### PR TITLE
use network settings from astute.yaml in ceph

### DIFF
--- a/deployment/puppet/ceph/manifests/init.pp
+++ b/deployment/puppet/ceph/manifests/init.pp
@@ -19,11 +19,11 @@ class ceph (
       # TODO: calculate PG numbers
       $osd_pool_default_pg_num          = '100',
       $osd_pool_default_pgp_num         = '100',
-      $cluster_network                  = $::storage_network_range,
-      $public_network                   = $::management_network_range,
+      $cluster_network                  = $::fuel_settings['storage_network_range'],
+      $public_network                   = $::fuel_settings['management_network_range'],
 
       # RadosGW settings
-      $rgw_host                         = $::hostname,
+      $rgw_host                         = $::fqdn,
       $rgw_port                         = '6780',
       $rgw_keyring_path                 = '/etc/ceph/keyring.radosgw.gateway',
       $rgw_socket_path                  = '/tmp/radosgw.sock',


### PR DESCRIPTION
A couple ceph class parameters were missed in transition to astute.yaml.
