### PR TITLE
cleanup unused class parameters in osnailyfacter

### DIFF
--- a/deployment/puppet/openstack/manifests/controller.pp
+++ b/deployment/puppet/openstack/manifests/controller.pp
@@ -161,8 +161,6 @@ class openstack::controller (
   $quantum_config          = {},
   $quantum_network_node    = false,
   $quantum_netnode_on_cnt  = false,
-  $segment_range           = '1:4094',
-  $tenant_network_type     = 'gre',
   $enabled                 = true,
   $api_bind_address        = '0.0.0.0',
   $service_endpoint        = '127.0.0.1',
@@ -337,8 +335,6 @@ class openstack::controller (
     quantum_config          => $quantum_config,
     quantum_network_node    => $quantum_network_node,
     quantum_netnode_on_cnt  => $quantum_netnode_on_cnt,
-    segment_range           => $segment_range,
-    tenant_network_type     => $tenant_network_type,
     # Nova
     nova_user_password      => $nova_user_password,
     nova_db_password        => $nova_db_password,

--- a/deployment/puppet/openstack/manifests/nova/controller.pp
+++ b/deployment/puppet/openstack/manifests/nova/controller.pp
@@ -49,8 +49,6 @@ class openstack::nova::controller (
   $quantum_config            = {},
   $quantum_network_node      = false,
   $quantum_netnode_on_cnt    = false,
-  $segment_range             = '1:4094',
-  $tenant_network_type       = 'gre',
   # Nova
   $nova_db_user              = 'nova',
   $nova_db_dbname            = 'nova',

--- a/deployment/puppet/osnailyfacter/examples/site.pp
+++ b/deployment/puppet/osnailyfacter/examples/site.pp
@@ -36,8 +36,6 @@ if $::fuel_settings['nodes'] {
   $base_syslog_hash     = $::fuel_settings['base_syslog']
   $syslog_hash          = $::fuel_settings['syslog']
 
-
-  $use_quantum = $::fuel_settings['quantum']
   if (!empty(filter_nodes($::fuel_settings['nodes'], 'role', 'ceph-osd')) or
     $::fuel_settings['storage']['volumes_ceph'] or
     $::fuel_settings['storage']['images_ceph'] or
@@ -48,7 +46,7 @@ if $::fuel_settings['nodes'] {
     $use_ceph = false
   }
 
-
+  $use_quantum = $::fuel_settings['quantum']
   if $use_quantum {
     prepare_network_config($::fuel_settings['network_scheme'])
     $public_int   = get_network_role_property('ex', 'interface')
@@ -118,8 +116,8 @@ $cinder_rate_limits = {
 
 ###
 class advanced_node_netconfig {
-    $sdn = generate_network_config()
-    notify {"SDN: ${sdn}": }
+  $sdn = generate_network_config()
+  notify {"SDN: ${sdn}": }
 }
 
 case $::operatingsystem {
@@ -137,9 +135,9 @@ class os_common {
   class {"l23network::hosts_file": stage => 'netconfig', nodes => $nodes_hash }
   class {'l23network': use_ovs=>$use_quantum, stage=> 'netconfig'}
   if $use_quantum {
-      class {'advanced_node_netconfig': stage => 'netconfig' }
+    class {'advanced_node_netconfig': stage => 'netconfig' }
   } else {
-      class {'osnailyfacter::network_setup': stage => 'netconfig'}
+    class {'osnailyfacter::network_setup': stage => 'netconfig'}
   }
 
   class {'openstack::firewall': stage => 'openstack-firewall'}

--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -3,31 +3,22 @@ class osnailyfacter::cluster_ha {
   ##PARAMETERS DERIVED FROM YAML FILE
 
   if $::use_quantum {
-    $novanetwork_params  = {}
+    $novanetwork_params = {}
     $quantum_config = sanitize_quantum_config($::fuel_settings, 'quantum_settings')
   } else {
-    $quantum_hash = {}
-    $quantum_params = {}
-    $quantum_config = {}
-    $novanetwork_params  = $::fuel_settings['novanetwork_parameters']
-    $network_size         = $novanetwork_params['network_size']
-    $num_networks         = $novanetwork_params['num_networks']
-    $vlan_start           = $novanetwork_params['vlan_start']
+    $quantum_config     = {}
+    $novanetwork_params = $::fuel_settings['novanetwork_parameters']
+    $network_size       = $novanetwork_params['network_size']
+    $num_networks       = $novanetwork_params['num_networks']
+    $vlan_start         = $novanetwork_params['vlan_start']
   }
 
-  if $cinder_nodes {
-    $cinder_nodes_array   = $::fuel_settings['cinder_nodes']
-  }
-  else {
-    $cinder_nodes_array = []
-  }
+  # All hash assignment from a dimensional hash must be in the local
+  # scope or they will be undefined (don't move to site.pp)
 
-  # All hash assignment from a dimensional hash must be in the local scope or they will
-  #  be undefined (don't move to site.pp)
-
-  #These aren't always present.
+  # These aren't always present.
   if !$::fuel_settings['savanna'] {
-    $savanna_hash={}
+    $savanna_hash = {}
   } else {
     $savanna_hash = $::fuel_settings['savanna']
   }
@@ -90,22 +81,6 @@ class osnailyfacter::cluster_ha {
 
   $vip_keys = keys($vips)
 
-  if ($::fuel_settings['cinder']) {
-    if (member($cinder_nodes_array,'all')) {
-      $is_cinder_node = true
-    } elsif (member($cinder_nodes_array,$::hostname)) {
-      $is_cinder_node = true
-    } elsif (member($cinder_nodes_array,$internal_address)) {
-      $is_cinder_node = true
-    } elsif ($node[0]['role'] =~ /controller/ ) {
-      $is_cinder_node = member($cinder_nodes_array,'controller')
-    } else {
-      $is_cinder_node = member($cinder_nodes_array,$node[0]['role'])
-    }
-  } else {
-    $is_cinder_node = false
-  }
-
   #$quantum_host            = $::fuel_settings['management_vip']
 
   ##REFACTORING NEEDED
@@ -121,7 +96,6 @@ class osnailyfacter::cluster_ha {
   $controller_node_public  = $::fuel_settings['public_vip']
   $controller_node_address = $::fuel_settings['management_vip']
   $mountpoints = filter_hash($mp_hash,'point')
-  $quantum_metadata_proxy_shared_secret = $quantum_config['metadata']['metadata_proxy_shared_secret']
 
   $quantum_gre_bind_addr = $::internal_address
 

--- a/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
@@ -1,44 +1,40 @@
 class osnailyfacter::cluster_simple {
 
-	if $::use_quantum
-	{
-	  $quantum_hash   = $::fuel_settings['quantum_access']
-	  $quantum_params = $::fuel_settings['quantum_parameters']
-	  $novanetwork_params  = {}
+  ##PARAMETERS DERIVED FROM YAML FILE
+
+	if $::use_quantum {
+	  $novanetwork_params = {}
+    $quantum_config = sanitize_quantum_config($::fuel_settings, 'quantum_settings')
 	} else {
-	  $quantum_hash = {}
-	  $quantum_params = {}
-	  $novanetwork_params  = $::fuel_settings['novanetwork_parameters']
+    $quantum_config     = {}
+	  $novanetwork_params = $::fuel_settings['novanetwork_parameters']
+    $network_size       = $novanetwork_params['network_size']
+    $num_networks       = $novanetwork_params['num_networks']
+    $vlan_start         = $novanetwork_params['vlan_start']
 	}
 
-	if $fuel_settings['cinder_nodes'] {
-	   $cinder_nodes_array   = $::fuel_settings['cinder_nodes']
-	} else {
-	  $cinder_nodes_array = []
-	}
-	
-	# All hash assignment from a dimensional hash must be in the local scope or they will
-	#  be undefined (don't move to site.pp)
-	
-	#These aren't always present.
+  # All hash assignment from a dimensional hash must be in the local
+  # scope or they will be undefined (don't move to site.pp)
+
+	# These aren't always present.
 	if !$::fuel_settings['savanna'] {
-	  $savanna_hash={}
+	  $savanna_hash = {}
 	} else {
 	  $savanna_hash = $::fuel_settings['savanna']
 	}
-	
+
 	if !$::fuel_settings['murano'] {
 	  $murano_hash = {}
 	} else {
 	  $murano_hash = $::fuel_settings['murano']
 	}
-	
+
 	if !$::fuel_settings['heat'] {
 	  $heat_hash = {}
 	} else {
 	  $heat_hash = $::fuel_settings['heat']
 	}
- 
+
 
 	$storage_hash         = $::fuel_settings['storage']
 	$nova_hash            = $::fuel_settings['nova']
@@ -54,8 +50,6 @@ class osnailyfacter::cluster_simple {
 	$network_manager      = "nova.network.manager.${novanetwork_params['network_manager']}"
 	$network_size         = $novanetwork_params['network_size']
 	$num_networks         = $novanetwork_params['num_networks']
-	$tenant_network_type  = $quantum_params['tenant_network_type']
-	$segment_range        = $quantum_params['segment_range']
 
 	if !$rabbit_hash[user] {
 	  $rabbit_hash[user] = 'nova'
@@ -76,28 +70,11 @@ class osnailyfacter::cluster_simple {
 	$controller_node_public = $controller[0]['public_address']
 
 
-	if ($::fuel_settings['cinder']) {
-	  if (member($cinder_nodes_array,'all')) {
-	    $is_cinder_node = true
-	  } elsif (member($cinder_nodes_array,$::hostname)) {
-	    $is_cinder_node = true
-	  } elsif (member($cinder_nodes_array,$internal_address)) {
-	    $is_cinder_node = true
-	  } elsif ($node[0]['role'] =~ /controller/ ) {
-	    $is_cinder_node = member($cinder_nodes_array,'controller')
-	  } else {
-	    $is_cinder_node = member($cinder_nodes_array,$node[0]['role'])
-	  }
-	} else {
-	  $is_cinder_node = false
-	}
-
-
 	$cinder_iscsi_bind_addr = $::storage_address
-	
+
 	# do not edit the below line
 	validate_re($::queue_provider,  'rabbitmq|qpid')
-	
+
 	$network_config = {
 	  'vlan_start'     => $vlan_start,
 	}
@@ -105,19 +82,17 @@ class osnailyfacter::cluster_simple {
 	$mirror_type = 'external'
 	$multi_host              = true
 	Exec { logoutput => true }
-	
+
 	$quantum_host            = $controller_node_address
 	$quantum_sql_connection  = "mysql://${quantum_db_user}:${quantum_db_password}@${quantum_host}/${quantum_db_dbname}"
-	$quantum_metadata_proxy_shared_secret = $quantum_params['metadata_proxy_shared_secret']
-	$quantum_gre_bind_addr = $::internal_address
 
 	if !$::fuel_settings['verbose'] {
-	 $verbose = false
+    $verbose = false
 	}
-	
-	if !$::fuel_settings['debug'] {
-	 $debug = false
-	}
+
+  if !$::fuel_settings['debug'] {
+    $debug = false
+  }
 
 	# Determine who should get the volume service
 	if ($::fuel_settings['role'] == 'cinder' or
@@ -130,8 +105,8 @@ class osnailyfacter::cluster_simple {
 	  $manage_volumes = false
 	}
 
-	#Determine who should be the default backend
-	
+	# Determine who should be the default backend
+
 	if ($storage_hash['images_ceph']) {
 	  $glance_backend = 'ceph'
 	} else {
@@ -192,14 +167,9 @@ class osnailyfacter::cluster_simple {
         qpid_user               => $rabbit_hash[user],
         export_resources        => false,
         quantum                 => $::use_quantum,
-        quantum_user_password         => $quantum_hash[user_password],
-        quantum_db_password           => $quantum_hash[db_password],
-        quantum_network_node          => $::use_quantum,
-        quantum_netnode_on_cnt        => true,
-        quantum_gre_bind_addr         => $quantum_gre_bind_addr,
-        quantum_external_ipinfo       => $external_ipinfo,
-        tenant_network_type           => $tenant_network_type,
-        segment_range                 => $segment_range,
+        quantum_config          => $quantum_config,
+        quantum_network_node    => $::use_quantum,
+        quantum_netnode_on_cnt  => true,
         cinder                  => true,
         cinder_user_password    => $cinder_hash[user_password],
         cinder_db_password      => $cinder_hash[db_password],
@@ -217,44 +187,22 @@ class osnailyfacter::cluster_simple {
         horizon_use_ssl         => $horizon_use_ssl,
         nameservers             => $::dns_nameservers,
       }
+
       nova_config { 'DEFAULT/start_guests_on_host_boot': value => $::fuel_settings['start_guests_on_host_boot'] }
       nova_config { 'DEFAULT/use_cow_images': value => $::fuel_settings['use_cow_images'] }
       nova_config { 'DEFAULT/compute_scheduler_driver': value => $::fuel_settings['compute_scheduler_driver'] }
+
       if $::quantum {
         class { '::openstack::quantum_router':
-	        db_host               => $controller_node_address,
-		      service_endpoint      => $controller_node_address,
-		      auth_host             => $controller_node_address,
-		      nova_api_vip          => $controller_node_address,
-		      internal_address      => $internal_address,
-		      public_interface      => $::public_int,
-		      private_interface     => $::fuel_settings['fixed_interface'],
-		      floating_range        => $floating_hash,
-		      fixed_range           => $::fuel_settings['fixed_network_range'],
-		      create_networks       => $create_networks,
-		      debug                 => $debug ? { 'true' => true, true => true, default=> false },
-		      verbose               => $verbose ? { 'true' => true, true => true, default=> false },
-		      queue_provider        => $queue_provider,
-		      rabbit_password       => $rabbit_hash[password],
-		      rabbit_user           => $rabbit_hash[user],
-		      rabbit_ha_virtual_ip  => $controller_node_address,
-		      rabbit_nodes          => [$controller_node_address],
-		      qpid_password         => $rabbit_hash[password],
-		      qpid_user             => $rabbit_hash[user],
-		      qpid_nodes            => [$controller_node_address],
-		      quantum               => $::use_quantum,
-		      quantum_user_password => $quantum_hash[user_password],
-		      quantum_db_password   => $quantum_hash[db_password],
-		      quantum_gre_bind_addr => $quantum_gre_bind_addr,
-		      quantum_network_node  => true,
-		      quantum_netnode_on_cnt=> $::use_quantum,
-		      tenant_network_type   => $tenant_network_type,
-		      segment_range         => $segment_range,
-		      external_ipinfo       => $external_ipinfo,
-		      api_bind_address      => $internal_address,
-		      use_syslog            => $use_syslog,
-		      syslog_log_level      => $syslog_log_level,
-		      syslog_log_facility   => $syslog_log_facility_quantum,
+          debug                 => $debug ? { 'true' => true, true => true, default=> false },
+          verbose               => $verbose ? { 'true' => true, true => true, default=> false },
+          quantum               => $::use_quantum,
+          quantum_config        => $quantum_config,
+          quantum_network_node  => $quantum_network_node,
+          api_bind_address      => $internal_address,
+          use_syslog            => $use_syslog,
+          syslog_log_level      => $syslog_log_level,
+          syslog_log_facility   => $syslog_log_facility_quantum,
         }
       }
 
@@ -351,50 +299,47 @@ class osnailyfacter::cluster_simple {
       include osnailyfacter::test_compute
 
       class { 'openstack::compute':
-        public_interface       => $::public_int,
-        private_interface      => $::fuel_settings['fixed_interface'],
-        internal_address       => $internal_address,
-        libvirt_type           => $::fuel_settings['libvirt_type'],
-        fixed_range            => $::fuel_settings['fixed_network_range'],
-        network_manager        => $network_manager,
-        network_config         => $network_config,
-        multi_host             => $multi_host,
-        sql_connection         => $sql_connection,
-        nova_user_password     => $nova_hash[user_password],
-        queue_provider         => $::queue_provider,
-        rabbit_nodes           => [$controller_node_address],
-        rabbit_password        => $rabbit_hash[password],
-        rabbit_user            => $rabbit_user,
-        auto_assign_floating_ip => $::fuel_settings['auto_assign_floating_ip'], 
-        qpid_nodes             => [$controller_node_address],
-        qpid_password          => $rabbit_hash[password],
-        qpid_user              => $rabbit_user,
-        glance_api_servers     => "${controller_node_address}:9292",
-        vncproxy_host          => $controller_node_public,
-        vnc_enabled            => true,
-        quantum                => $::use_quantum,
-        quantum_host           => $quantum_host,
-        quantum_sql_connection => $quantum_sql_connection,
-        quantum_user_password  => $quantum_hash[user_password],
-        tenant_network_type    => $tenant_network_type,
-        service_endpoint       => $controller_node_address,
-        cinder                 => true,
-        cinder_user_password   => $cinder_hash[user_password],
-        cinder_db_password     => $cinder_hash[db_password],
-        cinder_iscsi_bind_addr  => $cinder_iscsi_bind_addr,
-        cinder_volume_group     => "cinder",
-        manage_volumes          => $manage_volumes,
-        db_host                => $controller_node_address,
-        debug                  => $debug ? { 'true' => true, true => true, default=> false },
-        verbose                => $verbose ? { 'true' => true, true => true, default=> false },
-        use_syslog             => true,
-        syslog_log_level       => $syslog_log_level,
-        syslog_log_facility    => $syslog_log_facility_nova,
+        public_interface            => $::public_int,
+        private_interface           => $::fuel_settings['fixed_interface'],
+        internal_address            => $internal_address,
+        libvirt_type                => $::fuel_settings['libvirt_type'],
+        fixed_range                 => $::fuel_settings['fixed_network_range'],
+        network_manager             => $network_manager,
+        network_config              => $network_config,
+        multi_host                  => $multi_host,
+        sql_connection              => $sql_connection,
+        nova_user_password          => $nova_hash[user_password],
+        queue_provider              => $::queue_provider,
+        rabbit_nodes                => [$controller_node_address],
+        rabbit_password             => $rabbit_hash[password],
+        rabbit_user                 => $rabbit_user,
+        auto_assign_floating_ip     => $::fuel_settings['auto_assign_floating_ip'], 
+        qpid_nodes                  => [$controller_node_address],
+        qpid_password               => $rabbit_hash[password],
+        qpid_user                   => $rabbit_user,
+        glance_api_servers          => "${controller_node_address}:9292",
+        vncproxy_host               => $controller_node_public,
+        vnc_enabled                 => true,
+        quantum                     => $::use_quantum,
+        quantum_config              => $quantum_config,
+        service_endpoint            => $controller_node_address,
+        cinder                      => true,
+        cinder_user_password        => $cinder_hash[user_password],
+        cinder_db_password          => $cinder_hash[db_password],
+        cinder_iscsi_bind_addr      => $cinder_iscsi_bind_addr,
+        cinder_volume_group         => "cinder",
+        manage_volumes              => $manage_volumes,
+        db_host                     => $controller_node_address,
+        debug                       => $debug ? { 'true' => true, true => true, default=> false },
+        verbose                     => $verbose ? { 'true' => true, true => true, default=> false },
+        use_syslog                  => true,
+        syslog_log_level            => $syslog_log_level,
+        syslog_log_facility         => $syslog_log_facility_nova,
         syslog_log_facility_quantum => $syslog_log_facility_quantum,
-        syslog_log_facility_cinder => $syslog_log_facility_cinder,
-        state_path             => $nova_hash[state_path],
-        nova_rate_limits       => $nova_rate_limits,
-        cinder_rate_limits     => $cinder_rate_limits
+        syslog_log_facility_cinder  => $syslog_log_facility_cinder,
+        state_path                  => $nova_hash[state_path],
+        nova_rate_limits            => $nova_rate_limits,
+        cinder_rate_limits          => $cinder_rate_limits
       }
       nova_config { 'DEFAULT/start_guests_on_host_boot': value => $::fuel_settings['start_guests_on_host_boot'] }
       nova_config { 'DEFAULT/use_cow_images': value => $::fuel_settings['use_cow_images'] }

--- a/deployment/puppet/quantum/lib/puppet/provider/quantum.rb
+++ b/deployment/puppet/quantum/lib/puppet/provider/quantum.rb
@@ -48,14 +48,6 @@ class Puppet::Provider::Quantum < Puppet::Provider
     @quantum_file
   end
 
-  # def self.quantum_hash
-  #   @quantum_hash ||= build_quantum_hash
-  # end
-
-  # def quantum_hash
-  #   self.class.quantum_hash
-  # end
-
   def self.auth_quantum(*args)
     #todo: Rewrite, using ruby-openstack
     begin


### PR DESCRIPTION
Parameters that are no longer used are:
- quantum_hash, quantum_params: superceded by quantum_config
- segment_range, tenant_network_type, quantum_gre_bind_addr,
  quantum_external_ipinfo, quantum_user_password, quantum_db_password,
  quantum_host, quantum_sql_connection: no longer referenced anywhere
- cinder_nodes, cinder_nodes_array, is_cinder_node: no longer used

Copy-pasted parameters not recognized by openstack::quantum_router
removed from its declaration in cluster_simple.pp.

Change includes indentation fixes in affected code areas.
