### PR TITLE
Ubuntu CEPH fixes

### DIFF
--- a/deployment/puppet/ceph/manifests/params.pp
+++ b/deployment/puppet/ceph/manifests/params.pp
@@ -44,7 +44,7 @@ class ceph::params {
       $service_radosgw            = 'radosgw'
       $package_radosgw            = 'radosgw'
       $package_fastcgi            = 'libapache2-mod-fastcgi'
-      $package_modssl             = ''
+      $package_modssl             = undef
       $dir_httpd_conf             = '/etc/httpd/conf/'
       $dir_httpd_sites            = '/etc/apache2/sites-available/'
       $dir_httpd_ssl              = '/etc/apache2/ssl/'

--- a/deployment/puppet/glance/manifests/backend/ceph.pp
+++ b/deployment/puppet/glance/manifests/backend/ceph.pp
@@ -21,7 +21,7 @@ class glance::backend::ceph(
     'DEFAULT/rbd_store_user':          value => $rbd_store_user;
     'DEFAULT/rbd_store_pool':          value => $rbd_store_pool;
     'DEFAULT/show_image_direct_url':   value => $show_image_direct_url;
-  }~> Service[$::ceph::params::service_glance_api]
+  }~> Service['glance-api']
 
   exec {'Create Glance Ceph client ACL':
     # DO NOT SPLIT ceph auth command lines! See http://tracker.ceph.com/issues/3279
@@ -35,7 +35,7 @@ class glance::backend::ceph(
     before  => File[$glance_keyring],
     creates => $glance_keyring,
     require => Exec['Create Glance Ceph client ACL'],
-    notify  => Service["${::ceph::params::service_glance_api}"],
+    notify  => Service['glance-api'],
     returns => 0,
   }
 


### PR DESCRIPTION
Fixes some errors found in the ceph deployment.
- fix error in glance::backend:ceph using wrong glance-api name
- fix mod_ssl package name
