### PR TITLE
Ceph radosgw fixes FOR TESTING - DO NOT MERGE

### DIFF
--- a/deployment/puppet/ceph/manifests/init.pp
+++ b/deployment/puppet/ceph/manifests/init.pp
@@ -90,6 +90,8 @@ class ceph (
         Class['ceph::libnss'] ->
         Class[['ceph::keystone', 'ceph::radosgw']] ~>
         Service['ceph']
+
+        Class['::keystone'] -> Class[['ceph::keystone', 'ceph::radosgw']]
       }
     }
 

--- a/deployment/puppet/ceph/manifests/init.pp
+++ b/deployment/puppet/ceph/manifests/init.pp
@@ -28,6 +28,7 @@ class ceph (
       $rgw_keyring_path                 = '/etc/ceph/keyring.radosgw.gateway',
       $rgw_socket_path                  = '/tmp/radosgw.sock',
       $rgw_log_file                     = '/var/log/ceph/radosgw.log',
+      $rgw_use_keystone                 = $::token_format ? { 'PKI'=>true, default=>false },
       $rgw_keystone_url                 = "${cluster_node_address}:5000",
       $rgw_keystone_admin_token         = $::fuel_settings['keystone']['admin_token'],
       $rgw_keystone_token_cache_size    = '10',

--- a/deployment/puppet/ceph/manifests/keystone.pp
+++ b/deployment/puppet/ceph/manifests/keystone.pp
@@ -1,42 +1,38 @@
 #ceph::keystone will configure keystone with ceph parts
 class ceph::keystone (
-  $pub_ip    = $::ceph::rgw_pub_ip,
-  $adm_ip    = $::ceph::rgw_adm_ip,
-  $int_ip    = $::ceph::rgw_int_ip,
-  $rgw_port  = $::ceph::rgw_port,
-  $use_ssl   = $::ceph::use_ssl,
-  $directory = $::ceph::rgw_nss_db_path,
-  $httpd_ssl = $::ceph::params::dir_httpd_ssl,
+  $pub_ip           = $::ceph::rgw_pub_ip,
+  $adm_ip           = $::ceph::rgw_adm_ip,
+  $int_ip           = $::ceph::rgw_int_ip,
+  $rgw_use_keystone = $::ceph::rgw_use_keystone,
+  $rgw_port         = $::ceph::rgw_port,
+  $use_ssl          = $::ceph::use_ssl,
+  $directory        = $::ceph::rgw_nss_db_path,
+  $httpd_ssl        = $::ceph::params::dir_httpd_ssl,
 ) {
-  if ($use_ssl) {
-    exec {'copy OpenSSL certificates':
-      command => "scp -r ${directory}/* ${::ceph::primary_mon}:${directory} && \
-                  ssh ${::ceph::primary_mon} '/etc/init.d/radosgw restart'",
+  if ($rgw_use_keystone) {
+    if ($use_ssl) {
+      exec {'copy OpenSSL certificates':
+        command => "scp -r ${directory}/* ${::ceph::primary_mon}:${directory} && \
+                    ssh ${::ceph::primary_mon} '/etc/init.d/radosgw restart'",
+      }
+      exec {"generate SSL certificate on ${name}":
+        command => "openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ${httpd_ssl}apache.key -out ${httpd_ssl}apache.crt -subj '/C=RU/ST=Russia/L=Saratov/O=Mirantis/OU=CA/CN=localhost'",
+        returns => [0,1],
+      }
     }
-    exec {"generate SSL certificate on ${name}":
-      command => "openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ${httpd_ssl}apache.key -out ${httpd_ssl}apache.crt -subj '/C=RU/ST=Russia/L=Saratov/O=Mirantis/OU=CA/CN=localhost'",
-      returns => [0,1],
+
+    keystone_service {'swift':
+      ensure      => present,
+      type        => 'object-store',
+      description => 'Openstack Object-Store Service',
     }
-  }
 
-  keystone_service {'swift':
-    ensure      => present,
-    type        => 'object-store',
-    description => 'Openstack Object-Store Service',
-  }
-
-  keystone_endpoint {'swift':
-    ensure       => present,
-    region       => 'RegionOne',
-    public_url   => "http://${pub_ip}:${rgw_port}/swift/v1",
-    admin_url    => "http://${adm_ip}:${rgw_port}/swift/v1",
-    internal_url => "http://${int_ip}:${rgw_port}/swift/v1",
-  }
-
-  if ! defined(Class['keystone']) {
-    service { 'keystone':
-      ensure => 'running',
-      enable => true,
+    keystone_endpoint {'swift':
+      ensure       => present,
+      region       => 'RegionOne',
+      public_url   => "http://${pub_ip}:${rgw_port}/swift/v1",
+      admin_url    => "http://${adm_ip}:${rgw_port}/swift/v1",
+      internal_url => "http://${int_ip}:${rgw_port}/swift/v1",
     }
   }
 }

--- a/deployment/puppet/ceph/manifests/radosgw.pp
+++ b/deployment/puppet/ceph/manifests/radosgw.pp
@@ -36,9 +36,15 @@ class ceph::radosgw (
 
   package { [$::ceph::params::package_radosgw,
              $::ceph::params::package_fastcgi,
-             $::ceph::params::package_modssl,
             ]:
     ensure  => 'latest',
+  }
+
+  if ($::osfamily == "RedHat") {
+    package {$::ceph::params::package_modssl:
+      ensure  => 'latest',
+      notify  => Service['httpd']
+    }
   }
 
   service { 'radosgw':
@@ -157,8 +163,7 @@ class ceph::radosgw (
 
   Ceph_conf <||> ->
   Package[[$::ceph::params::package_radosgw,
-           $::ceph::params::package_fastcgi,
-           $::ceph::params::package_modssl,]] ->
+           $::ceph::params::package_fastcgi,]] ->
   File[["${::ceph::params::dir_httpd_sites}/rgw.conf",
         "${::ceph::params::dir_httpd_sites}/fastcgi.conf",
         "${dir_httpd_root}/s3gw.fcgi",

--- a/deployment/puppet/ceph/templates/fastcgi.conf.erb
+++ b/deployment/puppet/ceph/templates/fastcgi.conf.erb
@@ -1,0 +1,25 @@
+# This file is managed by Puppet
+
+# WARNING: this is a kludge:
+## The User/Group for httpd need to be set before we can load mod_fastcgi,
+## but /etc/httpd/conf.d/fastcgi.conf on RHEL gets loaded before
+## /etc/httpd/conf/httpd.conf, so we need to set them here :(
+## mod_fcgid does not have this bug,
+## but it does not handle child PHP processes appropriately per
+## http://serverfault.com/questions/303535/a-single-php-fastcgi-process-blocks-all-other-php-requests/305093#305093
+
+User apache
+Group apache
+
+LoadModule fastcgi_module modules/mod_fastcgi.so
+
+# dir for IPC socket files
+FastCgiIpcDir /var/run/mod_fastcgi
+
+# wrap all fastcgi script calls in suexec
+# Must be off in RHEL
+FastCgiWrapper Off
+
+# global FastCgiConfig can be overridden by FastCgiServer options in vhost config
+FastCgiConfig -idle-timeout 20 -maxClassProcesses 1
+

--- a/deployment/puppet/keystone/manifests/init.pp
+++ b/deployment/puppet/keystone/manifests/init.pp
@@ -273,8 +273,9 @@ class keystone(
     exec { 'keystone-manage pki_setup':
       path        => '/usr/bin',
       user        => 'keystone',
-      refreshonly => true,
+      creates     => '/etc/keystone/ssl',
     }
+
   }
 
   if $enabled {

--- a/deployment/puppet/openstack/manifests/controller.pp
+++ b/deployment/puppet/openstack/manifests/controller.pp
@@ -50,6 +50,8 @@
 # [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option
 #       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
 # [syslog_log_level] logging level for non verbose and non debug mode. Optional.
+# [token_format] Format keystone uses for tokens. Optional. Defaults to UUID (PKI is grizzly native mode though).
+#   Supports PKI and UUID.
 #
 # === Examples
 #
@@ -130,6 +132,7 @@ class openstack::controller (
   $keystone_db_user        = 'keystone',
   $keystone_db_dbname      = 'keystone',
   $keystone_admin_tenant   = 'admin',
+  $token_format            = 'UUID',
   # Glance
   $glance_db_user          = 'glance',
   $glance_db_dbname        = 'glance',
@@ -269,6 +272,7 @@ class openstack::controller (
     use_syslog            => $use_syslog,
     syslog_log_facility   => $syslog_log_facility_keystone,
     syslog_log_level      => $syslog_log_level,
+    token_format          => $token_format,
   }
 
 

--- a/deployment/puppet/openstack/manifests/controller_ha.pp
+++ b/deployment/puppet/openstack/manifests/controller_ha.pp
@@ -138,6 +138,7 @@ class openstack::controller_ha (
    $use_unicast_corosync    = false,
    $ha_mode                 = true,
    $nameservers             = undef,
+   $token_format            = 'UUID',
  ) {
 
     # haproxy
@@ -278,6 +279,7 @@ class openstack::controller_ha (
       keystone_db_password    => $keystone_db_password,
       keystone_admin_token    => $keystone_admin_token,
       keystone_admin_tenant   => $keystone_admin_tenant,
+      token_format            => $token_format,
       glance_db_password      => $glance_db_password,
       glance_user_password    => $glance_user_password,
       glance_api_servers      => $glance_api_servers,

--- a/deployment/puppet/openstack/manifests/keystone.pp
+++ b/deployment/puppet/openstack/manifests/keystone.pp
@@ -30,7 +30,8 @@
 # [syslog_log_facility] Facility for syslog, if used. Optional. Note: duplicating conf option
 #       wouldn't have been used, but more powerfull rsyslog features managed via conf template instead
 # [syslog_log_level] logging level for non verbose and non debug mode. Optional.
-#
+# [token_format] Format keystone uses for tokens. Optional. Defaults to UUID (PKI is grizzly native mode though).
+#   Supports PKI and UUID.
 # === Example
 #
 # class { 'openstack::keystone':
@@ -53,6 +54,7 @@ class openstack::keystone (
   $nova_user_password,
   $cinder_user_password,
   $public_address,
+  $token_format             = 'UUID',
   $db_type                  = 'mysql',
   $db_user                  = 'keystone',
   $db_name                  = 'keystone',
@@ -175,9 +177,10 @@ class openstack::keystone (
     sql_connection => $sql_conn,
     bind_host	=> $bind_host,
     package_ensure => $package_ensure,
-    use_syslog => $use_syslog,
+    use_syslog          => $use_syslog,
     syslog_log_facility => $syslog_log_facility,
     syslog_log_level    => $syslog_log_level,
+    token_format        => $token_format,
   }
 
   if ($enabled) {

--- a/deployment/puppet/osnailyfacter/examples/site.pp
+++ b/deployment/puppet/osnailyfacter/examples/site.pp
@@ -43,9 +43,11 @@ if $::fuel_settings['nodes'] {
     $::fuel_settings['storage']['images_ceph'] or
     $::fuel_settings['storage']['objects_ceph']
   ) {
-    $use_ceph = true
+    $use_ceph     = true
+    $token_format = 'PKI'
   } else {
     $use_ceph = false
+    $token_format = 'UUID'
   }
 
 

--- a/deployment/puppet/osnailyfacter/examples/site.pp
+++ b/deployment/puppet/osnailyfacter/examples/site.pp
@@ -44,7 +44,9 @@ if $::fuel_settings['nodes'] {
     $::fuel_settings['storage']['objects_ceph']
   ) {
     $use_ceph     = true
-    $token_format = 'PKI'
+    $token_format = $::osfamily ? { 'RedHat'=>'UUID', default=>'PKI' }
+    # PKI is needed for CEPH RadosGW < - > Keystone integration which
+    #  doesn't currently work in Python 2.6 distros (RedHat)
   } else {
     $use_ceph = false
     $token_format = 'UUID'

--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -242,6 +242,7 @@ class osnailyfacter::cluster_ha {
       keystone_db_password          => $keystone_hash[db_password],
       keystone_admin_token          => $keystone_hash[admin_token],
       keystone_admin_tenant         => $access_hash[tenant],
+      token_format                  => $::token_format,
       glance_db_password            => $glance_hash[db_password],
       glance_user_password          => $glance_hash[user_password],
       glance_image_cache_max_size   => $glance_hash[image_cache_max_size],

--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha_full.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha_full.pp
@@ -223,6 +223,7 @@ class ha_controller (
     keystone_db_password    => $keystone_hash[db_password],
     keystone_admin_token    => $keystone_hash[admin_token],
     keystone_admin_tenant   => $access_hash[tenant],
+    token_format            => $::token_format,
     glance_db_password      => $glance_hash[db_password],
     glance_user_password    => $glance_hash[user_password],
     nova_db_password        => $nova_hash[db_password],

--- a/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
@@ -165,6 +165,7 @@ class osnailyfacter::cluster_simple {
         keystone_db_password    => $keystone_hash[db_password],
         keystone_admin_token    => $keystone_hash[admin_token],
         keystone_admin_tenant   => $access_hash[tenant],
+        token_format            => $::token_format,
         glance_db_password      => $glance_hash[db_password],
         glance_user_password    => $glance_hash[user_password],
         glance_backend          => $glance_backend,


### PR DESCRIPTION
RadosGW requires keystone PKI token format, this would make keystone use PKI token_format when using ceph.

This requires https://mirantis.jira.com/browse/OSCI-363 for CentOS

This has not been tested, this is for testing and review
