### PR TITLE
cephx key and ceph pool management fixes

### DIFF
--- a/deployment/puppet/ceph/manifests/mon.pp
+++ b/deployment/puppet/ceph/manifests/mon.pp
@@ -33,18 +33,8 @@ class ceph::mon {
                ],
   }
 
-  # creates the named OSD pool
-  define osd_pool {
-    exec { "Creating pool ${name}":
-      command   => "ceph osd pool create ${name} ${::ceph::osd_pool_default_pg_num} ${::ceph::osd_pool_default_pgp_num}",
-      logoutput => true,
-    }
-  }
-  osd_pool {[$::ceph::cinder_pool, $::ceph::glance_pool]: }
-
   Firewall['010 ceph-mon allow'] ->
   Exec['ceph-deploy mon create'] ->
   Exec['Wait for Ceph quorum']   ->
-  Exec['ceph-deploy gatherkeys'] ->
-  Osd_pool <||>
+  Exec['ceph-deploy gatherkeys']
 }

--- a/deployment/puppet/ceph/manifests/pool.pp
+++ b/deployment/puppet/ceph/manifests/pool.pp
@@ -1,0 +1,45 @@
+# create a Ceph pool with an associated Cephx user and ACL
+
+define ceph::pool (
+  # Cephx user and ACL
+  $user = $name,
+  $acl  = "mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=${name}'",
+
+  # Unix user and group for the keyring file
+  $keyring_owner = $user,
+  $keyring_group = $keyring_owner,
+
+  # Pool settings
+  $pg_num  = $::ceph::osd_pool_default_pg_num,
+  $pgp_num = $::ceph::osd_pool_default_pgp_num,
+) {
+
+  exec {"Create ${name} pool":
+    command => "ceph osd pool create ${name} ${pg_num} ${pgp_num}",
+    unless  => "rados lspools | grep -q '^${name}$'",
+  }
+
+  exec {"Create ${user} Cephx user and ACL":
+    command => "ceph auth get-or-create client.${user} ${acl}",
+    unless  => "ceph auth list | grep -q '^client.${user}$'"
+  }
+
+  $keyring = "/etc/ceph/ceph.client.${user}.keyring"
+
+  exec {"Populate ${user} keyring":
+    command => "ceph auth get-or-create client.${user} > ${keyring}",
+    creates => $keyring,
+  }
+
+  file {$keyring:
+    ensure => file,
+    mode   => '0640',
+    owner  => $keyring_owner,
+    group  => $keyring_group,
+  }
+
+  Exec["Create ${name} pool"] ->
+  Exec["Create ${user} Cephx user and ACL"] ->
+  Exec["Populate ${user} keyring"] ->
+  File[$keyring]
+}

--- a/deployment/puppet/cinder/manifests/volume/ceph.pp
+++ b/deployment/puppet/cinder/manifests/volume/ceph.pp
@@ -1,8 +1,9 @@
+# configures the Ceph RBD backend for Cinder
 class cinder::volume::ceph (
   $volume_driver      = $::ceph::volume_driver,
-  $rbd_pool           = $::ceph::rbd_pool,
   $glance_api_version = $::ceph::glance_api_version,
-  $rbd_user           = $::ceph::rbd_user,
+  $rbd_pool           = $::ceph::cinder_pool,
+  $rbd_user           = $::ceph::cinder_user,
   $rbd_secret_uuid    = $::ceph::rbd_secret_uuid,
 ) {
 
@@ -16,40 +17,18 @@ class cinder::volume::ceph (
   File_line<||> ~> Service['cinder-volume']
   # TODO: this needs to be re-worked to follow https://wiki.openstack.org/wiki/Cinder-multi-backend
   cinder_config {
-    'DEFAULT/volume_driver':           value => $volume_driver;
-    'DEFAULT/rbd_pool':                value => $rbd_pool;
-    'DEFAULT/glance_api_version':      value => $glance_api_version;
-    'DEFAULT/rbd_user':                value => $rbd_user;
-    'DEFAULT/rbd_secret_uuid':         value => $rbd_secret_uuid;
+    'DEFAULT/volume_driver':      value => $volume_driver;
+    'DEFAULT/glance_api_version': value => $glance_api_version;
+    'DEFAULT/rbd_pool':           value => $rbd_pool;
+    'DEFAULT/rbd_user':           value => $rbd_user;
+    'DEFAULT/rbd_secret_uuid':    value => $rbd_secret_uuid;
   }
+
   # TODO: convert to cinder params
   file {$::ceph::params::service_cinder_volume_opts:
     ensure => 'present',
   } -> file_line {'cinder-volume.conf':
     path => $::ceph::params::service_cinder_volume_opts,
-    line => "export CEPH_ARGS='--id ${::ceph::cinder_pool}'",
-  }
-
-  exec {'Create Cinder Ceph client ACL':
-    # DO NOT SPLIT ceph auth command lines! See http://tracker.ceph.com/issues/3279
-    command   => "ceph auth get-or-create client.${::ceph::cinder_pool} mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=${::ceph::cinder_pool}, allow rx pool=${::ceph::glance_pool}'",
-    logoutput => true,
-  }
-
-  $cinder_keyring = "/etc/ceph/ceph.client.${::ceph::cinder_pool}.keyring"
-  exec {'Create keys for the Cinder pool':
-    command => "ceph auth get-or-create client.${::ceph::cinder_pool} > ${cinder_keyring}",
-    before  => File[$cinder_keyring],
-    creates => $cinder_keyring,
-    require => Exec['Create Cinder Ceph client ACL'],
-    notify  => Service['cinder-volume'],
-    returns => 0,
-  }
-
-  file {$cinder_keyring:
-    owner   => cinder,
-    group   => cinder,
-    require => Exec['Create keys for the Cinder pool'],
-    mode    => '0600',
+    line => "export CEPH_ARGS='--id ${rbd_pool}'",
   }
 }

--- a/deployment/puppet/glance/manifests/backend/ceph.pp
+++ b/deployment/puppet/glance/manifests/backend/ceph.pp
@@ -1,8 +1,8 @@
-#configures the glance blacked for ceph (rbd) driver
+# configures the Ceph RBD backend for Glance
 class glance::backend::ceph(
   $default_store         = 'rbd',
-  $rbd_store_user        = $::ceph::rbd_store_user,
-  $rbd_store_pool        = $::ceph::rbd_store_pool,
+  $rbd_store_user        = $::ceph::glance_user,
+  $rbd_store_pool        = $::ceph::glance_pool,
   $show_image_direct_url = $::ceph::show_image_direct_url,
 ) inherits glance::api {
 
@@ -17,32 +17,9 @@ class glance::backend::ceph(
   }
 
   glance_api_config {
-    'DEFAULT/default_store':           value => $default_store;
-    'DEFAULT/rbd_store_user':          value => $rbd_store_user;
-    'DEFAULT/rbd_store_pool':          value => $rbd_store_pool;
-    'DEFAULT/show_image_direct_url':   value => $show_image_direct_url;
+    'DEFAULT/default_store':         value => $default_store;
+    'DEFAULT/rbd_store_user':        value => $rbd_store_user;
+    'DEFAULT/rbd_store_pool':        value => $rbd_store_pool;
+    'DEFAULT/show_image_direct_url': value => $show_image_direct_url;
   }~> Service['glance-api']
-
-  exec {'Create Glance Ceph client ACL':
-    # DO NOT SPLIT ceph auth command lines! See http://tracker.ceph.com/issues/3279
-    command   => "ceph auth get-or-create client.${::ceph::glance_pool} mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=${::ceph::glance_pool}'",
-    logoutput => true,
-  }
-
-  $glance_keyring = "/etc/ceph/ceph.client.${::ceph::glance_pool}.keyring"
-  exec {'Create keys for the Glance pool':
-    command => "ceph auth get-or-create client.${::ceph::glance_pool} > ${$glance_keyring}",
-    before  => File[$glance_keyring],
-    creates => $glance_keyring,
-    require => Exec['Create Glance Ceph client ACL'],
-    notify  => Service['glance-api'],
-    returns => 0,
-  }
-
-  file {$glance_keyring:
-    owner   => glance,
-    group   => glance,
-    require => Exec['Create keys for the Glance pool'],
-    mode    => '0600',
-  }
 }


### PR DESCRIPTION
- consistently parametrize pools, Cephx users and ACLs
- unscatter creation of Cinder and Glance pools into ceph::pool
- use parameterized Cephx user when generating Nova secret
- create Glance pool before Cinder ACL

Testing status: deploy PASSED with CentOS simple, safe to merge.
