### PR TITLE
Fix missing CEPH monitors in HA

### DIFF
--- a/deployment/puppet/ceph/manifests/mon.pp
+++ b/deployment/puppet/ceph/manifests/mon.pp
@@ -11,7 +11,7 @@ class ceph::mon {
   exec {'ceph-deploy mon create':
     command   => "ceph-deploy mon create ${::hostname}:${::internal_address}",
     logoutput => true,
-    unless    => 'ceph -s',
+    unless    => 'ceph mon stat | grep ${::internal_address}',
     # TODO: need method to update mon_nodes in ceph.conf
   }
 


### PR DESCRIPTION
Fixes bug introduced by 0fdb733 where HA controllers after first would not create CEPH monitors because unless test passed in wrong condition.

Testing status:
CentOS HA - Pass

OK to merge.
