### PR TITLE
Correct RadosGW endpoint in HA

### DIFF
--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -149,7 +149,11 @@ class osnailyfacter::cluster_ha {
 
     class {'ceph':
       primary_mon                      => $primary_mon,
-      cluster_node_address             => $controller_node_public,
+      rgw_keystone_url                 => "${::fuel_settings['management_vip']}:5000",
+      # TODO: fix this with a propper vip in HA
+      rgw_pub_ip                       => $controllers[0]['public_address'],
+      rgw_adm_ip                       => $controllers[0]['public_address'],
+      rgw_int_ip                       => $controllers[0]['public_address'],
       use_rgw                          => $storage_hash['objects_ceph'],
       glance_backend                   => $glance_backend,
     }


### PR DESCRIPTION
This will point swift endpoint to first controller because there is no VIP in HA for RadosGW and wont be ready in time for 3.2. This will need to be a known limitation in 3.2

Testing status:
centos HA - hand re-run pass
ubuntu HA - testing
