### PR TITLE
[PRD-2323] Fix cinder-volume ceph init on ubuntu

### DIFF
--- a/deployment/puppet/ceph/manifests/params.pp
+++ b/deployment/puppet/ceph/manifests/params.pp
@@ -3,10 +3,6 @@ class ceph::params {
 
   case $::osfamily {
     'RedHat': {
-      $service_cinder_volume      = 'openstack-cinder-volume'
-      $service_cinder_volume_opts = '/etc/sysconfig/openstack-cinder-volume'
-      $service_glance_api         = 'openstack-glance-api'
-      $service_glance_registry    = 'openstack-glance-registry'
       $service_nova_compute       = 'openstack-nova-compute'
       #RadosGW
       $service_httpd              = 'httpd'
@@ -31,10 +27,6 @@ class ceph::params {
     }
 
     'Debian': {
-      $service_cinder_volume      = 'cinder-volume'
-      $service_cinder_volume_opts = '/etc/init/cinder-volume.conf'
-      $servic_glance_api          = 'glance-api'
-      $service_glance_registry    = 'glance-registry'
       $service_nova_compute       = 'nova-compute'
       #RadosGW
       $service_httpd              = 'apache2'

--- a/deployment/puppet/cinder/manifests/params.pp
+++ b/deployment/puppet/cinder/manifests/params.pp
@@ -13,6 +13,8 @@ class cinder::params {
       $scheduler_service = 'cinder-scheduler'
       $volume_package    = 'cinder-volume'
       $volume_service    = 'cinder-volume'
+      $volume_opts_file  = '/etc/init/cinder-volume.conf'
+
       $db_sync_command   = 'cinder-manage db sync'
 
       $tgt_package_name  = 'tgt'
@@ -34,6 +36,7 @@ class cinder::params {
       $api_service       = 'openstack-cinder-api'
       $scheduler_service = 'openstack-cinder-scheduler'
       $volume_service    = 'openstack-cinder-volume'
+      $volume_opts_file  = '/etc/sysconfig/openstack-cinder-volume'
 
       $db_sync_command   = 'cinder-manage db sync'
 

--- a/deployment/puppet/cinder/manifests/volume/ceph.pp
+++ b/deployment/puppet/cinder/manifests/volume/ceph.pp
@@ -7,11 +7,7 @@ class cinder::volume::ceph (
   $rbd_secret_uuid    = $::ceph::rbd_secret_uuid,
 ) {
 
-  require ::ceph
-
-  Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
-         cwd  => '/root',
-  }
+  include cinder::params
 
   Cinder_config<||> ~> Service['cinder-volume']
   File_line<||> ~> Service['cinder-volume']
@@ -24,11 +20,42 @@ class cinder::volume::ceph (
     'DEFAULT/rbd_secret_uuid':    value => $rbd_secret_uuid;
   }
 
-  # TODO: convert to cinder params
-  file {$::ceph::params::service_cinder_volume_opts:
-    ensure => 'present',
-  } -> file_line {'cinder-volume.conf':
-    path => $::ceph::params::service_cinder_volume_opts,
-    line => "export CEPH_ARGS='--id ${rbd_pool}'",
+#  # TODO: convert to cinder params
+#  file {$::ceph::params::service_cinder_volume_opts:
+#    ensure => 'present',
+#  } -> file_line {'cinder-volume.conf':
+#    path => $::ceph::params::service_cinder_volume_opts,
+#    line => "export CEPH_ARGS='--id ${rbd_pool}'",
+#  }
+
+  case $::osfamily {
+    'RedHat': {
+      $volume_opts = "export CEPH_ARGS='--id ${rbd_pool}'"
+    }
+    'Debian': {
+      $volume_opts = "env CEPH_ARGS='--id ${rbd_pool}'"
+    }
+    default: {
+      $volume_opts=undef
+    }
   }
+
+  file {'cinder-volume init file':
+    path    => $::cinder::params::volume_opts_file,
+    ensure  => present,
+  }
+
+  if ($::cinder::params::volume_package) {
+      $volume_package = $::cinder::params::volume_package
+    } else {
+      $volume_package = $::cinder::params::package_name
+  }
+
+  Package[$volume_package] -> File_line['cinder-volume init config']
+
+  file_line {'cinder-volume init config':
+    path    => $::cinder::params::volume_opts_file,
+    line    => "${volume_opts}",
+  } ~> Service['cinder-volume']
+
 }

--- a/deployment/puppet/glance/manifests/backend/ceph.pp
+++ b/deployment/puppet/glance/manifests/backend/ceph.pp
@@ -6,12 +6,6 @@ class glance::backend::ceph(
   $show_image_direct_url = $::ceph::show_image_direct_url,
 ) inherits glance::api {
 
-  require ::ceph
-
-  Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
-         cwd  => '/root',
-  }
-
   package {'python-ceph':
     ensure => latest,
   }


### PR DESCRIPTION
- distorize CEPH_ARGS in cinder::volume::ceph
- convert parameters to cinder::params
- remove un-used params from ceph::params
- removes some not needed parts left over from 0fdb733

Resolves: PRD-2323

Testing status: 
Centos HA - pass
Ubuntu - testing
