### PR TITLE
added puppet packages and deps for our custom projects

### DIFF
--- a/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
+++ b/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
@@ -10,11 +10,14 @@
 + c-ares19*
 + erlang*
 + euca2ools*
+* facter*
 + galera*
++ hiera*
 + http-parser*
 + libicu*
 + libuv*
 + mcollective*
++ *murano*
 + nailgun*
 + nginx*
 + nodejs*
@@ -41,6 +44,7 @@
 + rubygem-rake*
 + rubygem-stomp*
 + rubygems-*
++ *savanna*
 + scapy*
 + socat*
 + supervisor*

--- a/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
+++ b/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
@@ -5,12 +5,13 @@
 + GeoIP*
 + MySQL*wsrep*
 + MySQL-python*
++ augeas*
 + cirros-testvm*
 + crmsh*
 + c-ares19*
 + erlang*
 + euca2ools*
-* facter*
++ facter*
 + galera*
 + hiera*
 + http-parser*
@@ -34,6 +35,8 @@
 + python-virtualenv*
 + rabbitmq-server*
 + ruby-ri*
++ ruby-augeas*
++ ruby-shadow*
 + rubygem-daemons*
 + rubygem-fastthread
 + rubygem-gem_plugin

--- a/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
+++ b/deployment/puppet/rpmcache/files/req-fuel-rhel.txt
@@ -24,6 +24,7 @@
 + nodejs*
 + pssh*
 + puppet-*
++ pushy-*
 + python-amqp*
 + python-amqplib*
 + python-anyjson*

--- a/deployment/puppet/rpmcache/files/required-rpms.txt
+++ b/deployment/puppet/rpmcache/files/required-rpms.txt
@@ -53,6 +53,8 @@ libXinerama
 libXrandr
 libXrender
 libXxf86vm
+libguestfs-tools-c
+libselinux-ruby
 libpng
 librelp
 libqb-0.14.2
@@ -65,6 +67,7 @@ memcached
 mesa-libGL
 mesa-libGLU
 mlocate
+mod_fastcgi
 mpfr
 mysql
 mysql-libs
@@ -99,6 +102,7 @@ openvswitch-controller
 pacemaker
 pango
 patch
+pciutils
 policycoreutils
 postgresql
 postgresql-devel
@@ -109,6 +113,7 @@ python-anyjson
 python-argparse
 python-cinder
 python-devel
+python-heatclient
 python-keystone
 python-novaclient
 python-oslo-config
@@ -141,6 +146,7 @@ screen
 subscription-manager
 system-config-firewall-base
 tk
+tmux
 unixODBC
 unzip
 usermode

--- a/deployment/puppet/rpmcache/files/required-rpms.txt
+++ b/deployment/puppet/rpmcache/files/required-rpms.txt
@@ -55,6 +55,7 @@ libXrender
 libXxf86vm
 libpng
 librelp
+libqb-0.14.2
 libthai
 libtiff
 lokkit

--- a/deployment/puppet/rpmcache/files/required-rpms.txt
+++ b/deployment/puppet/rpmcache/files/required-rpms.txt
@@ -79,6 +79,7 @@ openssl-devel
 openssl098e
 openstack-cinder
 openstack-dashboard
+openstack-heat
 openstack-glance
 openstack-keystone
 openstack-nova


### PR DESCRIPTION
Extra deps needed for puppet have to be brought from fuel centos repo.
Murano and savanna are going to be copied to repo, but still are already disabled in UI. It will be necessary to do this later anyway for testing
