### PR TITLE
Allow verbose=true from site.pp

### DIFF
--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -184,9 +184,9 @@ class osnailyfacter::cluster_ha {
     'vlan_start'     => $vlan_start,
   }
 
-  if !$::fuel_settings['verbose'] {
-    $verbose = false
-  }
+  #if !$::fuel_settings['verbose'] {
+  #  $verbose = false
+  #}
 
   if !$::fuel_settings['debug'] {
     $debug = false
@@ -370,15 +370,15 @@ class osnailyfacter::cluster_ha {
         class { 'savanna' :
           savanna_enabled           => true,
           savanna_api_host          => $controller_node_address,
-          
+
           savanna_db_password       => $savanna_hash['db_password'],
           savanna_db_host           => $controller_node_address,
-          
+
           savanna_keystone_host     => $controller_node_address,
           savanna_keystone_user     => 'admin',
           savanna_keystone_password => 'admin',
           savanna_keystone_tenant   => 'admin',
-          
+
           use_neutron               => $::use_quantum,
         }
       }
@@ -389,10 +389,10 @@ class osnailyfacter::cluster_ha {
           murano_rabbit_host       => $controller_node_public,
           murano_rabbit_login      => 'murano',
           murano_rabbit_password   => $heat_hash['rabbit_password'],
-          
+
           murano_db_host           => $controller_node_address,
           murano_db_password       => $murano_hash['db_password'],
-          
+
           murano_keystone_host     => $controller_node_address,
           murano_keystone_user     => 'admin',
           murano_keystone_password => 'admin',
@@ -402,17 +402,17 @@ class osnailyfacter::cluster_ha {
         class { 'heat' :
           pacemaker              => true,
           external_ip            => $controller_node_public,
-          
+
           heat_keystone_host     => $controller_node_address,
           heat_keystone_user     => 'heat',
           heat_keystone_password => 'heat',
           heat_keystone_tenant   => 'services',
-          
+
           heat_rabbit_host       => $controller_node_address,
           heat_rabbit_login      => $rabbit_hash['user'],
           heat_rabbit_password   => $rabbit_hash['password'],
           heat_rabbit_port       => '5672',
-          
+
           heat_db_host           => $controller_node_address,
           heat_db_password       => $heat_hash['db_password'],
         }

--- a/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
@@ -98,9 +98,9 @@ class osnailyfacter::cluster_simple {
   $multi_host = true
   Exec { logoutput => true }
 
-  if !$::fuel_settings['verbose'] {
-   $verbose = false
-  }
+  #if !$::fuel_settings['verbose'] {
+  # $verbose = false
+  #}
 
   if !$::fuel_settings['debug'] {
    $debug = false
@@ -251,15 +251,15 @@ class osnailyfacter::cluster_simple {
         class { 'savanna' :
           savanna_enabled           => true,
           savanna_api_host          => $controller_node_address,
-          
+
           savanna_db_password       => $savanna_hash['db_password'],
           savanna_db_host           => $controller_node_address,
-          
+
           savanna_keystone_host     => $controller_node_address,
           savanna_keystone_user     => 'admin',
           savanna_keystone_password => 'admin',
           savanna_keystone_tenant   => 'admin',
-          
+
           use_neutron               => $::use_quantum,
         }
       }
@@ -270,10 +270,10 @@ class osnailyfacter::cluster_simple {
           murano_rabbit_host       => $controller_node_public,
           murano_rabbit_login      => 'murano',
           murano_rabbit_password   => $heat_hash['rabbit_password'],
-          
+
           murano_db_host           => $controller_node_address,
           murano_db_password       => $murano_hash['db_password'],
-          
+
           murano_keystone_host     => $controller_node_address,
           murano_keystone_user     => 'admin',
           murano_keystone_password => 'admin',
@@ -283,17 +283,17 @@ class osnailyfacter::cluster_simple {
         class { 'heat' :
           pacemaker              => false,
           external_ip            => $controller_node_public,
-          
+
           heat_keystone_host     => $controller_node_address,
           heat_keystone_user     => 'heat',
           heat_keystone_password => 'heat',
           heat_keystone_tenant   => 'services',
-          
+
           heat_rabbit_host       => $controller_node_address,
           heat_rabbit_login      => $rabbit_hash['user'],
           heat_rabbit_password   => $rabbit_hash['password'],
           heat_rabbit_port       => '5672',
-          
+
           heat_db_host           => $controller_node_address,
           heat_db_password       => $heat_hash['db_password'],
         }


### PR DESCRIPTION
Prevent hardcoded verbose option from being
overrided by False.s

Fixes: #PRD-2348

Signed-off-by: Bogdan Dobrelya bogdando@mail.ru
