### PR TITLE
always enable haproxy for swift or radosgw in HA

### DIFF
--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -177,6 +177,8 @@ class osnailyfacter::cluster_ha {
     } else {
       $primary_proxy = false
     }
+  } elsif ($storage_hash['objects_ceph']) {
+    $rgw_balancers = $controller_storage_addresses
   }
 
 
@@ -251,6 +253,7 @@ class osnailyfacter::cluster_ha {
       export_resources              => false,
       glance_backend                => $glance_backend,
       swift_proxies                 => $swift_proxies,
+      rgw_balancers                 => $rgw_balancers,
       quantum                       => $::use_quantum,
       quantum_config                => $quantum_config,
       quantum_network_node          => $::use_quantum,


### PR DESCRIPTION
Setup Swift HAProxy when Swift is enabled either for glance or for objects, not just when it's enabled for glance. Setup RadosGW HAProxy when Swift is disabled and RadosGW is enabled. Use active-passive balancing for RadosGW.

Fixes: PRD-2424 (swift is inaccessible when Ceph is enabled for Glance)
Testing: PASSED with Ubuntu HA nova-network w/o radosgw, PASSED with Ubuntu HA nova-network with radosgw, PASSED with Ubuntu HA GRE with radosgw. Ready to merge.
