### PR TITLE
Ubuntu install full vim by default

### DIFF
--- a/deployment/puppet/cobbler/templates/snippets/ubuntu_packages.erb
+++ b/deployment/puppet/cobbler/templates/snippets/ubuntu_packages.erb
@@ -1,4 +1,4 @@
-#set $pkgsel_packages = ["openssh-server", "debconf-utils", "ntp", "ruby-ipaddress", "ruby-netaddr", "ruby-openstack", "libaugeas-ruby", "libstomp-ruby1.8", "libshadow-ruby1.8", "libjson-ruby1.8", "vlan", "curl", "anacron", "python-amqp", "nailgun-agent", "nailgun-mcagents", "lvm2", "nailgun-net-check", "dhcp-checker", "puppet", "gdisk" ]
+#set $pkgsel_packages = ["openssh-server", "debconf-utils", "ntp", "ruby-ipaddress", "ruby-netaddr", "ruby-openstack", "libaugeas-ruby", "libstomp-ruby1.8", "libshadow-ruby1.8", "libjson-ruby1.8", "vim", "vlan", "curl", "anacron", "python-amqp", "nailgun-agent", "nailgun-mcagents", "lvm2", "nailgun-net-check", "dhcp-checker", "puppet", "gdisk" ]
 
 #if $str($getVar('mco_auto_setup','')) == "1"
     #silent $pkgsel_packages.append("ruby-stomp")


### PR DESCRIPTION
Add full vim package to Ubuntu installs, the current vi package provides very bad user experience. the vim package is already in the repo.
