### PR TITLE
Update Ceph OSD device list generation

### DIFF
--- a/deployment/puppet/ceph/lib/facter/ceph_osd.rb
+++ b/deployment/puppet/ceph/lib/facter/ceph_osd.rb
@@ -1,19 +1,38 @@
 Facter.add("osd_devices_list") do
     setcode do
-        # Use any filesystem labeled "cephosd" as an osd
-        devs = %x{blkid -o list | awk '{if ($3 == "cephosd") print $1}'}.split("\n")
-        journal = %x{blkid -o list | awk '{if ($3 == "cephjournal") print $1}'}.split("\n")
+        devs = %x{lsblk -ln | awk '{if ($6 == "disk") print $1}'}.split("\n")
         output = []
+        osds = []
+        journals = []
 
-        if journal.length > 0
-          ratio = (devs.length * 1.0 / journal.length).ceil
+        # Finds OSD and journal devices based on Partition GUID
+        devs.each { |d|
+            parts = %x{ls /dev/#{d}?}.gsub("/dev/#{d}","").split("\n")
+            parts.each { |p|
+                code = %x{sgdisk -i #{p} /dev/#{d} | grep "Partition GUID code" | awk '{print $4}'}.strip()
+                case code
+                when "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D"
+                    # Only use unmounted devices
+                    if %x{grep -c /dev/#{d}#{p} /proc/mounts}.to_i == 0
+                        osds << "/dev/#{d}#{p}"
+                    end
+                when "45B0969E-9B03-4F30-B4C6-B4B80CEFF106"
+                    if %x{grep -c /dev/#{d}#{p} /proc/mounts}.to_i == 0
+                        journals << "/dev/#{d}#{p}"
+                    end
+                end
+            }
+        }
+
+        if journals.length > 0
+          ratio = (osds.length * 1.0 / journals.length).ceil
           ratio = ratio > 1 ? ratio : 1
-          devs.each_slice(ratio) { |s|
-            j = journal.shift
+          osds.each_slice(ratio) { |s|
+            j = journals.shift
             output << s.map{|d| "#{d}:#{j}"}
           }
         else
-            output = devs
+            output = osds
         end
         output.join(" ")
     end


### PR DESCRIPTION
Facter function now uses partition GUID instead of filesystem label to find matching devices. It also excludes already mounted devices. This depends on https://review.openstack.org/#/c/54841/. See also https://bugs.launchpad.net/fuel/+bug/1246513. 
