### PR TITLE
PXE boot using HTTP instead of TFTP

### DIFF
--- a/deployment/puppet/cobbler/manifests/init.pp
+++ b/deployment/puppet/cobbler/manifests/init.pp
@@ -75,6 +75,7 @@ class cobbler(
   class { ::cobbler::iptables : }
   class { ::cobbler::snippets : }
   class { ::cobbler::server : }
+  class { ::cobbler::pxehttp : }
 
   cobbler_digest_user {$cobbler_user:
     password => $cobbler_password,

--- a/deployment/puppet/cobbler/manifests/packages.pp
+++ b/deployment/puppet/cobbler/manifests/packages.pp
@@ -22,7 +22,7 @@ class cobbler::packages {
       $cobbler_web_package = "cobbler-web"
       $cobbler_web_package_version = "2.2.3-2.el6"
       $dnsmasq_package = "dnsmasq"
-      $cobbler_additional_packages = ["xinetd", "tftp-server", "syslinux", "wget", "python-ipaddr"]
+      $cobbler_additional_packages = ["xinetd", "tftp-server", "syslinux", "wget", "python-ipaddr", "gpxe-bootimgs"]
       $django_package = "Django"
       $django_version = "1.3.4-1.el6"
     }

--- a/deployment/puppet/cobbler/manifests/pxehttp.pp
+++ b/deployment/puppet/cobbler/manifests/pxehttp.pp
@@ -1,0 +1,11 @@
+class cobbler::pxehttp(
+  $pxe_root = "/var/lib/tftpboot",
+  ){
+
+  file { "/etc/httpd/conf.d/pxe.conf":
+    content => template('cobbler/pxe_http.conf.erb'),
+    require => Package[$cobbler::packages::cobbler_web_package],
+    notify => Service[$cobbler::server::cobbler_web_service]
+  }
+
+}

--- a/deployment/puppet/cobbler/manifests/server.pp
+++ b/deployment/puppet/cobbler/manifests/server.pp
@@ -175,4 +175,11 @@ class cobbler::server {
     mode    => 0644,
   }
 
+  exec { "/var/lib/tftpboot/undionly.kpxe":
+    command => "cp /usr/share/gpxe/undionly.kpxe /var/lib/tftpboot/undionly.kpxe",
+    unless  => "test -e /var/lib/tftpboot/undionly.kpxe",
+    require => [
+      Package[$cobbler::packages::cobbler_additional_packages],
+      Package[$cobbler::packages::cobbler_package],]
+  }
 }

--- a/deployment/puppet/cobbler/templates/dnsmasq.template.erb
+++ b/deployment/puppet/cobbler/templates/dnsmasq.template.erb
@@ -25,7 +25,9 @@ dhcp-option=6,<%= @name_server %>
 
 dhcp-range=internal,<%= @dhcp_start_address %>,<%= @dhcp_end_address %>,<%= @dhcp_netmask %>
 dhcp-option=net:internal,option:router,<%= @dhcp_gateway %>
-pxe-service=net:#gpxe,x86PC,"Install",pxelinux,<%= @next_server %>
-dhcp-boot=net:internal,pxelinux.0,boothost,<%= @next_server %>
+dhcp-boot=net:#gpxe,undionly.kpxe
+dhcp-boot=pxelinux.0
+dhcp-option-force=209,pxelinux.cfg
+dhcp-option-force=210,http://<%= @next_server %>/tftpboot/
 
 $insert_cobbler_system_definitions

--- a/deployment/puppet/cobbler/templates/pxe_http.conf.erb
+++ b/deployment/puppet/cobbler/templates/pxe_http.conf.erb
@@ -1,0 +1,1 @@
+Alias /tftpboot <%= @pxe_root %>


### PR DESCRIPTION
This can't be merged until gpxe-bootimgs is included in the mirrors. https://mirantis.jira.com/browse/OSCI-812
