### PR TITLE
[4.0] [PRD-2485] Add support for vlan splinters

### DIFF
--- a/deployment/puppet/l23network/manifests/l2/port.pp
+++ b/deployment/puppet/l23network/manifests/l2/port.pp
@@ -54,6 +54,12 @@ define l23network::l2::port (
       interface_properties => $interface_properties,
       skip_existing => $skip_existing
     }
+
+    if ($::kernelmajversion =~ /^(2.\d|3.[0-2])/ and $::use_vlan_splinters) {
+      L2_ovs_port[$port] ->
+      l23network::l2::splinters {$port: }
+    }
+
     Service<| title == 'openvswitch-service' |> -> L2_ovs_port[$port]
   }
 }

--- a/deployment/puppet/l23network/manifests/l2/splinters.pp
+++ b/deployment/puppet/l23network/manifests/l2/splinters.pp
@@ -1,0 +1,36 @@
+# == Define: l23network::l2::splinters
+#
+# Splinters will check if the passed interface(name) is known to possibly have
+#  issues and will turn on splinters.
+#
+# This requires that $::use_vlan_splinters is true (defaults to false)
+#
+# ===Parameters
+#
+# [*interface*] (optional) the name of the interface to test, defaults to $name
+
+#
+define l23network::l2::splinters (
+	$interface = $name
+  ) {
+
+  # This is a list of drivers that might need splinters to work with older kernels.
+  # From http://openvswitch.org/cgi-bin/ovsman.cgi?page=utilities%2Fovs-vlan-bug-workaround.8.in
+
+  $drivers = ['8139cp', 'acenic', 'amd8111e', 'atl1c', 'ATL1E', 'atl1', 'atl2',
+              'be2net', 'bna', 'bnx2', 'bnx2x', 'cnic', 'cxgb', 'cxgb3',
+              'e1000', 'e1000e', 'enic', 'forcedeth', 'igb', 'igbvf', 'ixgb',
+              'ixgbe', 'jme', 'ml4x_core', 'ns83820', 'qlge', 'r8169', 'S2IO',
+              'sky2', 'starfire', 'tehuti', 'tg3', 'typhoon', 'via-velocity',
+              'vxge', 'gianfar', 'ehea', 'stmmac', 'vmxnet3']
+  $grep_test = join($drivers, ' -e ')
+
+  exec { "inspect interface and enable splinters on interface ${interface}":
+          command   => "ovs-vsctl set interface ${interface} other-config:enable-vlan-splinters=true",
+          logoutput => on_failure,
+          onlyif    => "ethtool -i ${interface} | /bin/grep -q -e ${grep_test}",
+          path      => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+          require   => Package[$::l23network::params::ovs_packages]
+  }
+}
+

--- a/deployment/puppet/osnailyfacter/examples/site.pp
+++ b/deployment/puppet/osnailyfacter/examples/site.pp
@@ -57,6 +57,8 @@ if $::fuel_settings['nodes'] {
     $use_ceph = false
   }
 
+  # Should we evaluate and enable vlan splinters?
+  $use_vlan_splinters = false
 
   if $use_quantum {
     prepare_network_config($::fuel_settings['network_scheme'])


### PR DESCRIPTION
Add option use_vlan_splinters to site.pp. If enabled and kernelmajversion
 < 3.3 then vlan splinters will be enabled if the driver for an bridge
 interface is present in the devices list in l23network::l2::splinters.

This behavior is disabled by default as not all installs may suffer from this
 and should only be enabled when necessary.

Testing status: testing passed on virtual emulation of e1000

To test, change guest network controller to one of the drivers listed in splinters.pp (ie e1000) 
