### PR TITLE
[PRD-930] Use AMQP heartbeat for mcollective (for 4.0)

### DIFF
--- a/deployment/puppet/cobbler/templates/snippets/mcollective_conf.erb
+++ b/deployment/puppet/cobbler/templates/snippets/mcollective_conf.erb
@@ -33,6 +33,7 @@ plugin.rabbitmq.pool.1.host = $mco_host
 plugin.rabbitmq.pool.1.port = $mco_port
 plugin.rabbitmq.pool.1.user = $mco_user
 plugin.rabbitmq.pool.1.password = $mco_password
+plugin.rabbitmq.heartbeat_interval = 30
 #end if
 
 

--- a/deployment/puppet/cobbler/templates/snippets/ubuntu_mcollective_config.erb
+++ b/deployment/puppet/cobbler/templates/snippets/ubuntu_mcollective_config.erb
@@ -22,6 +22,7 @@ plugin.rabbitmq.pool.1.host = %(mco_host)s
 plugin.rabbitmq.pool.1.port = %(mco_port)s
 plugin.rabbitmq.pool.1.user = %(mco_user)s
 plugin.rabbitmq.pool.1.password = %(mco_password)s
+plugin.rabbitmq.heartbeat_interval = 30
 
 # Facts
 factsource = yaml

--- a/deployment/puppet/mcollective/templates/client.cfg.erb
+++ b/deployment/puppet/mcollective/templates/client.cfg.erb
@@ -25,6 +25,7 @@ plugin.rabbitmq.pool.1.host = <%= scope.lookupvar('mcollective::client::host') %
 plugin.rabbitmq.pool.1.port = <%= scope.lookupvar('mcollective::client::stompport') %>
 plugin.rabbitmq.pool.1.user = <%= scope.lookupvar('mcollective::client::user') %>
 plugin.rabbitmq.pool.1.password = <%= scope.lookupvar('mcollective::client::password') %>
+plugin.rabbitmq.heartbeat_interval = 30
 <% end -%>
 
 # Facts

--- a/deployment/puppet/mcollective/templates/client.cfg.ubuntu.erb
+++ b/deployment/puppet/mcollective/templates/client.cfg.ubuntu.erb
@@ -25,6 +25,7 @@ plugin.rabbitmq.pool.1.host = <%= scope.lookupvar('mcollective::client::host') %
 plugin.rabbitmq.pool.1.port = <%= scope.lookupvar('mcollective::client::stompport') %>
 plugin.rabbitmq.pool.1.user = <%= scope.lookupvar('mcollective::client::user') %>
 plugin.rabbitmq.pool.1.password = <%= scope.lookupvar('mcollective::client::password') %>
+plugin.rabbitmq.heartbeat_interval = 30
 <% end -%>
 
 # Facts


### PR DESCRIPTION
With new mcollective and stomp this changes available to detect fail connection to RabbitMQ server and automatically reconnect and prevent many problems.
