### PR TITLE
Fix syntax errors leftover from rebase

### DIFF
--- a/deployment/puppet/neutron/manifests/keystone/auth.pp
+++ b/deployment/puppet/neutron/manifests/keystone/auth.pp
@@ -1,5 +1,5 @@
 class neutron::keystone::auth (
-  neutron_config      = {},
+  $neutron_config     = {},
   $configure_endpoint = true,
   $service_type       = 'network',
   $public_address     = '127.0.0.1',
@@ -23,14 +23,14 @@ class neutron::keystone::auth (
   keystone_service { $neutron_config['keystone']['admin_user']:
     ensure      => present,
     type        => $service_type,
-    description => "Neutron Networking Service",
+    description => 'Neutron Networking Service',
   }
 
   if $configure_endpoint {
     # keystone_endpoint { "${region}/$neutron_config['keystone']['admin_user']":
     keystone_endpoint { $neutron_config['keystone']['admin_user']:
-      region       => $neutron_config['keystone']['auth_region'],
       ensure       => present,
+      region       => $neutron_config['keystone']['auth_region'],
       public_url   => "http://${public_address}:${neutron_config['server']['bind_port']}",
       admin_url    => "http://${admin_address}:${$neutron_config['server']['bind_port']}",
       internal_url => "http://${internal_address}:${$neutron_config['server']['bind_port']}",

--- a/deployment/puppet/openstack/manifests/nova/controller.pp
+++ b/deployment/puppet/openstack/manifests/nova/controller.pp
@@ -31,7 +31,7 @@ class openstack::nova::controller (
   # Nova Required
   $nova_user_password,
   $nova_db_password,
-  primary_controller         = false,
+  $primary_controller         = false,
   # Network
   $fixed_range               = '10.0.0.0/24',
   $floating_range            = false,


### PR DESCRIPTION
deployment/puppet/neutron/manifests/keystone/auth.pp
 add missing $ on
 fix double quote
 fix ensure not first

deployment/puppet/openstack/manifests/nova/controller.pp
 add missing $ on 34
