### PR TITLE
[3.2] Fix ceph, radosgw init issues

### DIFF
--- a/deployment/puppet/ceph/manifests/init.pp
+++ b/deployment/puppet/ceph/manifests/init.pp
@@ -74,6 +74,7 @@ class ceph (
     service {'ceph':
       ensure => 'running',
       enable => true,
+      require => Class['ceph::conf']
     }
   }
 
@@ -111,7 +112,7 @@ class ceph (
     'ceph-osd': {
       if ! empty($osd_devices) {
         include ceph::osd
-        Class['ceph::conf'] -> Class['ceph::osd'] -> Service['ceph']
+        Class['ceph::conf'] -> Class['ceph::osd'] ~> Service['ceph']
       }
     }
 


### PR DESCRIPTION
This patch forces $::operatingsystem == Ubuntu to use the debian init script
 instead of the upstart script for radosgw. This is necessary because the
 upstart script requires a parameter that breaks puppet's upstart provider.
 this resolves #1239348.

This patch more strickly sets the dependancy for service ceph in init.pp.
 This some errors found in #1250122.

Closes-bug #1250122
Closes-bug #1249348
