### PR TITLE
[nailgun] New node naming convention in ssh.config

### DIFF
--- a/deployment/puppet/nailgun/templates/root_ssh_config.erb
+++ b/deployment/puppet/nailgun/templates/root_ssh_config.erb
@@ -1,4 +1,4 @@
-Host slave-* controller-* compute-* storage-* 10.* 192.168.* 172.30.* 172.31.* 172.2?.* 172.1?.*
+Host node-* controller-* compute-* storage-* 10.* 192.168.* 172.30.* 172.31.* 172.2?.* 172.1?.*
 CheckHostIP no
 IdentityFile ~/.ssh/bootstrap.rsa
 IdentityFile ~/.ssh/id_rsa


### PR DESCRIPTION
The slave nodes are called node-NN now istead of slave-NN.
