### PR TITLE
Exec rutun code fix

### DIFF
--- a/deployment/puppet/horizon/manifests/init.pp
+++ b/deployment/puppet/horizon/manifests/init.pp
@@ -208,7 +208,8 @@ class horizon(
         path    => '/bin:/usr/bin:/sbin:/usr/sbin',
         cwd     => '/usr/share/openstack-dashboard',
         command => 'python manage.py compress',
-        refreshonly => true
+        refreshonly => true,
+        returns => [0, ''],
       }
       Exec['horizon_compress_styles'] ~> Service['httpd']
     }


### PR DESCRIPTION
I have no idea why on Earth does Puppet's exec returns
empty string instread of command's return code.
This definitly should never happen at all but
suprisingly it does.

Don't merge until tested.
