### PR TITLE
[cobbler] Fix MCO server template for Ubuntu

### DIFF
--- a/deployment/puppet/cobbler/templates/snippets/ubuntu_mcollective_config.erb
+++ b/deployment/puppet/cobbler/templates/snippets/ubuntu_mcollective_config.erb
@@ -7,9 +7,15 @@ main_collective = mcollective
 collectives = mcollective
 libdir = /usr/share/mcollective/plugins
 logfile = /var/log/mcollective.log
-loglevel = info
+loglevel = debug
 daemonize = 0
 direct_addressing = 1
+
+# Set huge value of ttl to avoid cases with unsyncronized time between nodes
+# bash$ date -d '2033-5-18 3:33:20 UTC' +%s
+# 2000000000
+# It means that ttl equals 63 years and a half.
+ttl = 2000000000
 
 # Plugins
 securityprovider = psk


### PR DESCRIPTION
Log level is 'debug' and ttl set to 63 years.
