### PR TITLE
Fuel utils and quantum keys

### DIFF
--- a/deployment/puppet/quantum/files/ocf/quantum-agent-dhcp
+++ b/deployment/puppet/quantum/files/ocf/quantum-agent-dhcp
@@ -321,6 +321,7 @@ quantum_dhcp_agent_start() {
 
     # detach deffered rescheduling procedure
     bash -c "sleep 13 ; q-agent-cleanup.py --agent=dhcp --reschedule --remove-dead 2>&1 >> /var/log/quantum/rescheduling.log" &
+    fuel-fdb-cleaner --ssh-keyfile /root/.ssh/id_rsa_quantum -l /var/log/quantum/dhcp-fdb-cleaner.log
 
     ocf_log info "OpenStack DHCP Server (quantum-dhcp-agent) started"
     return $OCF_SUCCESS

--- a/deployment/puppet/quantum/files/ocf/quantum-agent-l3
+++ b/deployment/puppet/quantum/files/ocf/quantum-agent-l3
@@ -352,6 +352,7 @@ quantum_l3_agent_start() {
 
     # detach deffered rescheduling procedure
     bash -c "sleep 13 ; q-agent-cleanup.py --agent=l3 --reschedule --remove-dead 2>&1 >> /var/log/quantum/rescheduling.log" &
+    fuel-fdb-cleaner --ssh-keyfile /root/.ssh/id_rsa_quantum -l /var/log/quantum/l3-fdb-cleaner.log
 
     ocf_log info "OpenStack Router (quantum-l3-agent) started"
     return $OCF_SUCCESS

--- a/deployment/puppet/quantum/manifests/params.pp
+++ b/deployment/puppet/quantum/manifests/params.pp
@@ -34,6 +34,7 @@ class quantum::params {
       $python_path        = 'python2.7/dist-packages'
       $cidr_package       = 'ipcalc'
       $vlan_package       = 'vlan'
+      $fuel_utils_package = 'fuel-utils'
 
       case $::operatingsystem {
         'Debian': {
@@ -78,6 +79,7 @@ class quantum::params {
       $linuxbridge_config_file    = '/etc/quantum/plugins/linuxbridge/linuxbridge_conf.ini'
 
       $metadata_agent_service = 'quantum-metadata-agent'
+      $fuel_utils_package = [ 'fuel-utils', 'python-ecdsa' ]
     }
   }
 }


### PR DESCRIPTION
Experimantal FDP table cleaning tool.

Don't merge!

Installs ssh keys to allow access between all computes and controllers which may not be what you want security-wise.

OCF scripts also should be made templates to avoid key path hardcoding.
