### PR TITLE
Fix wget timeout in RHN satellite key download

### DIFF
--- a/deployment/puppet/cobbler/manifests/snippets.pp
+++ b/deployment/puppet/cobbler/manifests/snippets.pp
@@ -49,6 +49,7 @@ class cobbler::snippets {
   cobbler_snippet {"puppet_conf":}
   cobbler_snippet {"puppet_register_if_enabled":}
   cobbler_snippet {"red_hat_register_rhsm":}
+  cobbler_snippet {"red_hat_register_satellite":}
   cobbler_snippet {'ntp_register_if_enabled':}
   cobbler_snippet {"mcollective_install_if_enabled":}
   cobbler_snippet {"mcollective_conf":}

--- a/deployment/puppet/cobbler/templates/kickstart/centos.ks.erb
+++ b/deployment/puppet/cobbler/templates/kickstart/centos.ks.erb
@@ -209,7 +209,7 @@ $SNIPPET('ssh_disable_gssapi')
 
 # COBBLER EMBEDDED SNIPPET: 'redhat_register'
 # REGISTER AT REDHAT WITH ACTIVATION KEY
-$SNIPPET('redhat_register')
+$SNIPPET('red_hat_register_satellite')
 # REGISTER TO RED HAT SUBSCRIPTION MANAGER WITH LOGIN/PASSWORD
 $SNIPPET('red_hat_register_rhsm')
 

--- a/deployment/puppet/cobbler/templates/snippets/red_hat_register_satellite.erb
+++ b/deployment/puppet/cobbler/templates/snippets/red_hat_register_satellite.erb
@@ -1,0 +1,20 @@
+# begin Red Hat management server registration
+#if $redhat_management_type != "off" and $redhat_management_key != ""
+mkdir -p /usr/share/rhn/
+   #if $redhat_management_type == "site"
+      #set $mycert_file = "RHN-ORG-TRUSTED-SSL-CERT"
+      #set $mycert = "/usr/share/rhn/" + $mycert_file
+wget --tries=3 -T 5 http://$redhat_management_server/pub/RHN-ORG-TRUSTED-SSL-CERT -O $mycert
+perl -npe 's/RHNS-CA-CERT/$mycert_file/g' -i /etc/sysconfig/rhn/*
+   #end if
+   #if $redhat_management_type == "hosted"
+      #set $mycert = "/usr/share/rhn/RHNS-CA-CERT"
+   #end if
+   #set $endpoint = "https://%s/XMLRPC" % $redhat_management_server
+rhnreg_ks --serverUrl=$endpoint --sslCACert=$mycert --activationkey=$redhat_management_key
+#else
+# not configured to register to any Red Hat management server (ok)
+#end if
+# end Red Hat management server registration
+
+


### PR DESCRIPTION
wget http://$redhat_management_server/pub/RHN-ORG-TRUSTED-SSL-CERT -O $mycert takes 20 minutes (60s TCP timeout \* 20 retries) if there is DNS resolution but no internet access.

Rewrote Cobbler snippet to set a reasonable timeout if the connection can't be made.
https://bugs.launchpad.net/fuel/+bug/1257285
