### PR TITLE
Enabling vlan_splinters (4.0)

### DIFF
--- a/deployment/puppet/l23network/lib/facter/ovs_vlan_splinters.rb
+++ b/deployment/puppet/l23network/lib/facter/ovs_vlan_splinters.rb
@@ -1,0 +1,35 @@
+# Fact: l2_ovs_vlan_splinters_need_for
+#
+# Purpose: Return list of intefaces, that needs for enable OVS VLAN splinters.
+#
+Facter.add(:l2_ovs_vlan_splinters_need_for) do
+  need = Facter.value(:kernelmajversion) =~ /^(2.\d|3.[0-2])/
+  need = need.nil?  ?  false  :  true
+  rv = []
+  supported_drivers = [
+    '8139cp', 'acenic', 'amd8111e', 'atl1c', 'ATL1E', 'atl1', 'atl2',
+    'be2net', 'bna', 'bnx2', 'bnx2x', 'cnic', 'cxgb', 'cxgb3',
+    'e1000', 'e1000e', 'enic', 'forcedeth', 'igb', 'igbvf', 'ixgb',
+    'ixgbe', 'jme', 'ml4x_core', 'ns83820', 'qlge', 'r8169', 'S2IO',
+    'sky2', 'starfire', 'tehuti', 'tg3', 'typhoon', 'via-velocity',
+    'vxge', 'gianfar', 'ehea', 'stmmac', 'vmxnet3' #, 'pcnet32'
+  ]
+  interfaces = Facter.value(:interfaces)
+  if need and interfaces
+    for dev in interfaces.split(',').select{|x| x=~/^eth/} do
+      basedir = "/sys/class/net/#{dev}"
+      if ! (File.exists?(basedir) and File.exists?("#{basedir}/device/") and File.exists?("#{basedir}/device/uevent"))
+        next
+      end
+      driver = File.open("#{basedir}/device/uevent"){ |f| f.read }.split("\n").select{|x| x=~/^DRIVER=/}[0].split('=')[1]
+      if supported_drivers.index(driver)
+        rv.insert(-1, dev)
+      end
+    end
+  end
+  setcode do
+    rv.sort().join(',')
+  end
+end
+
+# vim: set ts=2 sw=2 et :

--- a/deployment/puppet/l23network/lib/puppet/parser/functions/generate_network_config.rb
+++ b/deployment/puppet/l23network/lib/puppet/parser/functions/generate_network_config.rb
@@ -197,9 +197,51 @@ Puppet::Parser::Functions::newfunction(:generate_network_config, :type => :rvalu
           :scope => self,
           :source => resource
       )
+
+      # setup trunks and vlan_splinters for phys.NIC
+      if (action == :port) and config_hash[:interfaces][trans[:name].to_sym] and  # does adding phys.interface?
+         config_hash[:interfaces][trans[:name].to_sym][:L2] and                   # does this interface have L2 section
+         config_hash[:interfaces][trans[:name].to_sym][:L2][:trunks] and          # does this interface have TRUNKS section
+         config_hash[:interfaces][trans[:name].to_sym][:L2][:trunks].is_a?(Array) and
+         config_hash[:interfaces][trans[:name].to_sym][:L2][:trunks].size() > 0   # does trunks section non empty?
+            Puppet.debug("Configure trunks and vlan_splinters for #{trans[:name]} (value is '#{config_hash[:interfaces][trans[:name].to_sym][:L2][:vlan_splinters]}')")
+            _do_trunks = true
+            if config_hash[:interfaces][trans[:name].to_sym][:L2][:vlan_splinters]
+              if config_hash[:interfaces][trans[:name].to_sym][:L2][:vlan_splinters] == 'on'
+                trans[:vlan_splinters] = true
+              elsif config_hash[:interfaces][trans[:name].to_sym][:L2][:vlan_splinters] == 'auto'
+                sp_nics = lookupvar('l2_ovs_vlan_splinters_need_for')
+                Puppet.debug("l2_ovs_vlan_splinters_need_for: #{sp_nics}")
+                if sp_nics and sp_nics != :undefined and sp_nics.split(',').index(trans[:name].to_s)
+                  Puppet.debug("enable vlan_splinters for: #{trans[:name].to_s}")
+                  trans[:vlan_splinters] = true
+                else
+                  trans[:vlan_splinters] = false
+                  if trans[:trunks] and trans[:trunks].size() >0
+                    Puppet.debug("disable vlan_splinters for: #{trans[:name].to_s}. Trunks will be set to '#{trans[:trunks].join(',')}'")
+                    config_hash[:interfaces][trans[:name].to_sym][:L2][:trunks] = []
+                  else
+                    Puppet.debug("disable vlan_splinters for: #{trans[:name].to_s}. Trunks for this interface also disabled.")
+                    _do_trunks = false
+                  end
+                end
+              else
+                trans[:vlan_splinters] = false
+              end
+            end
+            # add trunks list to the interface if it given
+            if _do_trunks
+              _trunks = [0] + trans[:trunks] + config_hash[:interfaces][trans[:name].to_sym][:L2][:trunks]  # zero for pass untagged traffic
+              _trunks.sort!().uniq!()
+              trans[:trunks] = _trunks
+            end
+            Puppet.debug("Configure trunks and vlan_splinters for #{trans[:name]} done.")
+      end
+
       trans.select{|k,v| k != :action}.each do |k,v|
         p_resource.set_parameter(k,v)
       end
+
       p_resource.set_parameter(:require, [previous]) if previous
       resource.instantiate_resource(self, p_resource)
       compiler.add_resource(self, p_resource)

--- a/deployment/puppet/l23network/lib/puppet/parser/functions/generate_network_config.rb
+++ b/deployment/puppet/l23network/lib/puppet/parser/functions/generate_network_config.rb
@@ -228,6 +228,8 @@ Puppet::Parser::Functions::newfunction(:generate_network_config, :type => :rvalu
               else
                 trans[:vlan_splinters] = false
               end
+            else
+              trans[:vlan_splinters] = false
             end
             # add trunks list to the interface if it given
             if _do_trunks

--- a/deployment/puppet/l23network/lib/puppet/provider/l2_ovs_port/ovs.rb
+++ b/deployment/puppet/l23network/lib/puppet/provider/l2_ovs_port/ovs.rb
@@ -54,6 +54,15 @@ Puppet::Type.type(:l2_ovs_port).provide(:ovs) do
         end
       end
     end
+    # enable vlan_splinters if need
+    if @resource[:vlan_splinters]
+      begin
+        vsctl('--', "set", "Port", @resource[:interface], "vlan_mode=trunk")
+        vsctl('--', "set", "Interface", @resource[:interface], "other-config:enable-vlan-splinters=true")
+      rescue Puppet::ExecutionFailure => error
+        raise Puppet::ExecutionFailure, "Interface '#{@resource[:interface]}' can't setup vlan_splinters:\n#{error}"
+      end
+    end
   end
 
   def destroy

--- a/deployment/puppet/l23network/lib/puppet/provider/l2_ovs_port/ovs.rb
+++ b/deployment/puppet/l23network/lib/puppet/provider/l2_ovs_port/ovs.rb
@@ -55,7 +55,8 @@ Puppet::Type.type(:l2_ovs_port).provide(:ovs) do
       end
     end
     # enable vlan_splinters if need
-    if @resource[:vlan_splinters]
+    if @resource[:vlan_splinters].to_s() == 'true'  # fucking puppet send non-boolean value instead true/false
+      Puppet.debug("Interface '#{@resource[:interface]}' vlan_splinters is '#{@resource[:vlan_splinters]}' [#{@resource[:vlan_splinters].class}]")
       begin
         vsctl('--', "set", "Port", @resource[:interface], "vlan_mode=trunk")
         vsctl('--', "set", "Interface", @resource[:interface], "other-config:enable-vlan-splinters=true")

--- a/deployment/puppet/l23network/lib/puppet/type/l2_ovs_port.rb
+++ b/deployment/puppet/l23network/lib/puppet/type/l2_ovs_port.rb
@@ -82,6 +82,12 @@ Puppet::Type.newtype(:l2_ovs_port) do
       end
     end
 
+    newparam(:vlan_splinters) do
+      newvalues(true, false)
+      defaultto(false)
+      desc "Enable vlan splinters (if it's a phys. interface)"
+    end
+
     autorequire(:l2_ovs_bridge) do
       [self[:bridge]]
     end

--- a/deployment/puppet/l23network/manifests/l2/port.pp
+++ b/deployment/puppet/l23network/manifests/l2/port.pp
@@ -38,6 +38,7 @@ define l23network::l2::port (
   $skip_existing = false,
   $tag           = 0,
   $trunks        = [],
+  $vlan_splinters= false
 ) {
   if ! $::l23network::l2::use_ovs {
     fail('You must enable Open vSwitch by setting the l23network::l2::use_ovs to true.')
@@ -50,6 +51,7 @@ define l23network::l2::port (
       type          => $type,
       tag           => $tag,
       trunks        => $trunks,
+      vlan_splinters=> $vlan_splinters,
       port_properties      => $port_properties,
       interface_properties => $interface_properties,
       skip_existing => $skip_existing


### PR DESCRIPTION
https://blueprints.launchpad.net/fuel/+spec/ovs-vlan-splinters
(porting from 3.2.1)
