### PR TITLE
Check corosync property for empty XML root

### DIFF
--- a/deployment/puppet/corosync/lib/puppet/provider/cs_property/crm.rb
+++ b/deployment/puppet/corosync/lib/puppet/provider/cs_property/crm.rb
@@ -102,7 +102,7 @@ Puppet::Type.type(:cs_property).provide(:crm, :parent => Puppet::Provider::Coros
         rescue
                 #pass
         end
-        if !result_xml.nil?
+        if !result_xml.nil? and !result_xml.root.nil?
                 debug("result_xml is #{result_xml.root.to_s}")
                 success = result_xml.root.attributes['value'] == @resource[:value]
         end


### PR DESCRIPTION
Fixes sporadic bugs on HA installations where cs_property
resource is not created after the first attempt.
