### PR TITLE
avoid kmod-openvswitch installation for non-2.6 kver

### DIFF
--- a/deployment/puppet/l23network/manifests/l2.pp
+++ b/deployment/puppet/l23network/manifests/l2.pp
@@ -16,7 +16,7 @@ class l23network::l2 (
        before => Package[$::l23network::params::ovs_packages],
      }
     }
-    if $::operatingsystem == 'Centos' {
+    if ( $::operatingsystem == 'Centos' and $::kernelmajversion == '2.6' ) {
      package { 'kmod-openvswitch':
        before => Package[$::l23network::params::ovs_packages],
      }


### PR DESCRIPTION
Proposed-for: https://blueprints.launchpad.net/fuel/+spec/cisco-ucs-imp
Milestone: 4.1
Deprecates: VLAN splinters usage
Depends-on: bound removal between kmod-openvswitch and openvswitch packages, nailgun kernel selection passthrough
